### PR TITLE
Add example of modifying token payload

### DIFF
--- a/api/authentication/jwt.md
+++ b/api/authentication/jwt.md
@@ -101,6 +101,23 @@ class CustomVerifier extends Verifier {
 app.configure(jwt({ Verifier: CustomVerifier }));
 ```
 
+### Adding Entries to Claim Payload
+By default, the claim of the token issued by the authentication service will contain the user's ID. By simply adding a hook to the service, the claim can be extended to contain additional entries. For instance, we can include the user's email address within the payload:
+```js
+app.service('authentication').hooks({
+  before: {
+    create: [
+      authentication.hooks.authenticate(config.strategies),
+      hook => {
+        hook.params.payload.email = hook.params.user.email;
+      },
+    ],
+    remove: [
+      authentication.hooks.authenticate('jwt'),
+    ],
+  },
+});
+```
 ## Client Usage
 
 When this module is registered server side, using the default config values this is how you can authenticate using `feathers-authentication-client`:


### PR DESCRIPTION
Saw this answered by @daffl [here](https://stackoverflow.com/questions/45974114/how-can-i-set-the-sub-claim-of-a-jwt-in-feathersjs)

Seems like a common enough scenario to include in the docs. I believe new users might otherwise unnecessarily find this process confusing since there isn't any code explicitly setting the userId claim within the generated `authentication.js`.