### PR TITLE
Preserve the name in the message

### DIFF
--- a/guides/chat/processing.md
+++ b/guides/chat/processing.md
@@ -41,6 +41,8 @@ module.exports = function() {
     // Override the original data
     hook.data = {
       text,
+      // Preserve the name in the message
+      name: hook.data.name,
       // Set the user id
       userId: user._id,
       // Add the current time via `getTime`


### PR DESCRIPTION
Preserve the name in the message in processMessage hook, if we doesn't  we will get undefined displayed as a sender name in chat app, because the name will be deleted in this hook.