### PR TITLE
Auth jwt recipe typo on test prop

### DIFF
--- a/guides/auth/recipe.customize-jwt-payload.md
+++ b/guides/auth/recipe.customize-jwt-payload.md
@@ -65,7 +65,7 @@ payload === {
   iss: 'feathers',
   sub: 'anonymous',
   userId: 1
-  test: true // Here's the new claim we just added
+  test: 'test' // Here's the new claim we just added
 }
 ```
 


### PR DESCRIPTION
There is a typo in test prop beacuse before you customize the jwt with { test: 'test' }