### PR TITLE
add link to auth api documentation

### DIFF
--- a/guides/auth/readme.md
+++ b/guides/auth/readme.md
@@ -1,5 +1,8 @@
 # Authentication Guides & Recipes
 
+[**API documentation**](/api/authentication/server.md)
+Currently, the API documentation is the most coherent documentation for authentication.
+
 [**How JWT Works**](./how-jwt-works.md)<br/>
 Learn more about JWT and how it might differ from authentication methods you've used, previously. (This guide is a work in progress.)
 


### PR DESCRIPTION
I had some trouble finding a good resource on auth documentation. After some days, I stumbled upon the API documentation, which seems to be the best resource as of now(?).

Adding this link might help others finding the documentation.