### PR TITLE
feathers-errors and auth-client links broken

### DIFF
--- a/api/authentication/client.md
+++ b/api/authentication/client.md
@@ -59,7 +59,7 @@ To enable `localStorage` on the client, be sure to set `storage: window.localSto
 
 After configuring this plugin, the Feathers client will have a few additional methods:
 
-### `feathersClient.authenticate(options)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/src/passport.js#L136)
+### `feathersClient.authenticate(options)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/lib/passport.js#L136)
 Authenticate with a Feathers server by passing a `strategy` and other properties as credentials. It will use whichever transport has been setup on the client (feathers-rest, feathers-socketio, or feathers-primus). Returns a Promise.
 
 ```js
@@ -90,16 +90,16 @@ app.authenticate().then(response => {
 })
 ```
 
-### `feathersClient.logout()` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/src/passport.js#L212)
+### `feathersClient.logout()` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/lib/passport.js#L212)
 Removes the JWT accessToken from storage on the client.  It also calls the `remove` method of the `/authentication` service on the Feathers server.
 
-### `feathersClient.passport.getJWT()` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/src/passport.js#L245)
+### `feathersClient.passport.getJWT()` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/lib/passport.js#L245)
 Pull the JWT from localstorage or the cookie. Returns a Promise.
 
-### `feathersClient.passport.verifyJWT(token)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/src/passport.js#L268)
+### `feathersClient.passport.verifyJWT(token)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/lib/passport.js#L268)
 Verify that a JWT is not expired and decode it to get the payload. Returns a Promise.
 
-### `feathersClient.passport.payloadIsValid(token)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/src/utils.js#L21)
+### `feathersClient.passport.payloadIsValid(token)` [source](https://github.com/feathersjs/feathers-authentication-client/blob/master/lib/utils.js#L21)
 Synchronously verify that a token has not expired. Returns a Boolean.
 
 ## Hooks

--- a/api/databases/mongoose.md
+++ b/api/databases/mongoose.md
@@ -170,7 +170,7 @@ You can run this example by using `node app` and go to [localhost:3030/messages]
 
 ## Querying, Validation
 
-Mongoose by default gives you the ability to add [validations at the model level](http://mongoosejs.com/docs/validation.html). Using an error handler like the one that [comes with Feathers](https://github.com/feathersjs/feathers-errors/blob/master/src/error-handler.js) your validation errors will be formatted nicely right out of the box!
+Mongoose by default gives you the ability to add [validations at the model level](http://mongoosejs.com/docs/validation.html). Using an error handler like the one that [comes with Feathers](https://github.com/feathersjs/feathers-errors/blob/master/lib/error-handler.js) your validation errors will be formatted nicely right out of the box!
 
 For more information on querying and validation refer to the [Mongoose documentation](http://mongoosejs.com/docs/guide.html).
 

--- a/api/databases/sequelize.md
+++ b/api/databases/sequelize.md
@@ -199,7 +199,7 @@ It is highly recommended to use `raw` queries, which is the default. However, th
     
 ## Validation
 
-Sequelize by default gives you the ability to [add validations at the model level](http://docs.sequelizejs.com/en/latest/docs/models-definition/#validations). Using an error handler like the one that [comes with Feathers](https://github.com/feathersjs/feathers-errors/blob/master/src/error-handler.js) your validation errors will be formatted nicely right out of the box!
+Sequelize by default gives you the ability to [add validations at the model level](http://docs.sequelizejs.com/en/latest/docs/models-definition/#validations). Using an error handler like the one that [comes with Feathers](https://github.com/feathersjs/feathers-errors/blob/master/lib/error-handler.js) your validation errors will be formatted nicely right out of the box!
 
 
 ## Migrations


### PR DESCRIPTION
Last of the bunch.

Only exception is https://docs.feathersjs.com/api/client.html#universal-isomorphic-api
which links to https://github.com/feathersjs/feathers/blob/master/src/client/express.js

I can't see where it moved based on content.

> ## Universal (Isomorphic) API
> 
> The Feathers Client uses the same [Application API](./application.md) as is available on the server.  It is extremely lightweight, however, with Express having been replaced by a [thin wrapper](https://github.com/feathersjs/feathers/blob/master/src/client/express.js). 