### PR TITLE
Fix: Nav buttons disable click whitespace to focus UI pattern

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -184,5 +184,5 @@ section.markdown-section table {
 /* make nav buttons smaller as to not accidentally trigger when you mean to click on white space. */
 .navigation {
   max-height: 40px;
-  margin-top: 56%;
+  margin-top: 46%;
 }

--- a/styles/website.css
+++ b/styles/website.css
@@ -180,3 +180,9 @@ section.markdown-section table {
 .book .book-summary ul.summary > li[data-level="1.2"] > ul > li > a {
   font-weight: bold;
 }
+
+/* make nav buttons smaller as to not accidentally trigger when you mean to click on white space. */
+.navigation {
+  max-height: 40px;
+  margin-top: 56%;
+}


### PR DESCRIPTION
make nav buttons smaller as to not accidentally trigger when you mean to click on whitespace.

How to Reproduce:
1. go to https://docs.feathersjs.com/api/hooks-common.html
2. scroll way down to something of interest
3. open a terminal
4. click on whitespace to bring back focus to the window and allow you to scroll
5. find that what you thought was white space is in fact a massive button
6. click on your browsers navigate forward button
7. find that you've lost your place in the document
8. ponder upon your existence and how could such an annoying feature could live this long
9. rejoice in the fact that there is a pull request to fix it