### PR TITLE
Fix 'iff' conditional hook example...

### DIFF
--- a/guides/step-by-step/basic-feathers/writing-hooks.md
+++ b/guides/step-by-step/basic-feathers/writing-hooks.md
@@ -481,7 +481,7 @@ You can combine predicates provided with the common hooks, such as `isProvider`
 You can write your own, or mix and match.
 
 ```javascript
-iff (hook => !isProvider('service')(hook) && hook.params.user.security >= 3, ...)
+iff (hook => !isProvider('server')(hook) && hook.params.user.security >= 3, ...)
 ```
 
 The `isNot` conditional utility


### PR DESCRIPTION
`... !isProvider('service')...` on line 484 should use `'server'` not `'service'`

Reported in https://github.com/feathersjs/docs/issues/890