### PR TITLE
Buzzard api docs: rename `hook` object to `context` object; a few typo fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": false,
+  "eslint.autoFixOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.formatOnSave": false,
-  "eslint.autoFixOnSave": true
-}

--- a/api/authentication/hooks.md
+++ b/api/authentication/hooks.md
@@ -33,7 +33,7 @@ app.service('messages').before({
 - `as` (default: 'userId') [optional] - The id field for a user on the resource you are requesting.
 - `expandPaths` (default: true) [optional] - Prevent path expansion when the DB Adapter doesn't support it. Ex: With this option set to false, a value like 'foo.userId' won't be expanded to a nested `{ "foo": { "userId": 51 } }` but instead be set as `{ "foo.userId": 51 }`.
 
-When using this hook with the default options the `User._id` will be copied into `hook.params.query.userId`.
+When using this hook with the default options the `User._id` will be copied into `context.params.query.userId`.
 
 
 ## restrictToOwner
@@ -61,7 +61,7 @@ app.service('messages').before({
 
 ## restrictToAuthenticated
 
-The `restrictToAuthenticated` hook throws an error if there isn't a logged-in user by checking for the `hook.params.user` object. It can be used on **any** service method and is intended to be used as a **before** hook. It doesn't take any arguments.
+The `restrictToAuthenticated` hook throws an error if there isn't a logged-in user by checking for the `context.params.user` object. It can be used on **any** service method and is intended to be used as a **before** hook. It doesn't take any arguments.
 
 ```js
 const hooks = require('feathers-authentication-hooks');
@@ -75,7 +75,7 @@ app.service('user').before({
 
 #### Options
 
-- `entity` (default: 'user') [optional] - The property name on `hook.params` to check for
+- `entity` (default: 'user') [optional] - The property name on `context.params` to check for
 
 
 ## associateCurrentUser

--- a/api/authentication/local-management.md
+++ b/api/authentication/local-management.md
@@ -154,7 +154,7 @@ therefore `patch` may *not* have a `auth.hashPassword()` hook.
 The user must be signed in before being allowed to change their password or communication values.
 The service, for feathers-authenticate v1.x, requires hooks similar to:
 ```javascript
-    const isAction = (...args) => hook => args.includes(hook.data.action);
+    const isAction = (...args) => context => args.includes(context.data.action);
     app.service('authManagement').before({
       create: [
         hooks.iff(isAction('passwordChange', 'identityChange'), auth.hooks.authenticate('jwt')),

--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -79,7 +79,7 @@ app.service('users').hooks({
 
 ```js
 {
-  passwordField: 'password', // key name of password field to look on hook.data
+  passwordField: 'password', // key name of password field to look on context.data
   hash: customHashFunction // default is the bcrypt hash function. Takes in a password and returns a hash.
 }
 ```

--- a/api/authentication/oauth1.md
+++ b/api/authentication/oauth1.md
@@ -142,25 +142,25 @@ app.configure(oauth1({
 }));
 
 function customizeTwitterProfile() {
-  return function(hook) {
+  return function(context) {
     console.log('Customizing Twitter Profile');
     // If there is a twitter field they signed up or
     // signed in with twitter so let's pull the email. If
-    if (hook.data.twitter) {
-      hook.data.email = hook.data.twitter.email; 
+    if (context.data.twitter) {
+      context.data.email = context.data.twitter.email; 
     }
 
     // If you want to do something whenever any OAuth
     // provider authentication occurs you can do this.
-    if (hook.params.oauth) {
+    if (context.params.oauth) {
       // do something for all OAuth providers
     }
 
-    if (hook.params.oauth.provider === 'twitter') {
+    if (context.params.oauth.provider === 'twitter') {
       // do something specific to the twitter provider
     }
 
-    return Promise.resolve(hook);
+    return Promise.resolve(context);
   };
 }
 

--- a/api/authentication/oauth2.md
+++ b/api/authentication/oauth2.md
@@ -143,25 +143,25 @@ app.configure(oauth2({
 }));
 
 function customizeGithubProfile() {
-  return function(hook) {
+  return function(context) {
     console.log('Customizing Github Profile');
     // If there is a github field they signed up or
     // signed in with github so let's pull the primary account email.
-    if (hook.data.github) {
-      hook.data.email = hook.data.github.profile.emails.find(email => email.primary).value;
+    if (context.data.github) {
+      context.data.email = context.data.github.profile.emails.find(email => email.primary).value;
     }
 
     // If you want to do something whenever any OAuth
     // provider authentication occurs you can do this.
-    if (hook.params.oauth) {
+    if (context.params.oauth) {
       // do something for all OAuth providers
     }
 
-    if (hook.params.oauth.provider === 'github') {
+    if (context.params.oauth.provider === 'github') {
       // do something specific to the github provider
     }
 
-    return Promise.resolve(hook);
+    return Promise.resolve(context);
   };
 }
 

--- a/api/channels.md
+++ b/api/channels.md
@@ -53,7 +53,7 @@ module.exports = function(app) {
 
   // A global publisher that sends all events to all authenticated clients
   app.publish((data, context) => {
-    return app.channel('authenticated);
+    return app.channel('authenticated');
   });
 };
 ```

--- a/api/channels.md
+++ b/api/channels.md
@@ -52,7 +52,7 @@ module.exports = function(app) {
   });
 
   // A global publisher that sends all events to all authenticated clients
-  app.publish((data, hook) => {
+  app.publish((data, context) => {
     return app.channel('authenticated);
   });
 };
@@ -195,7 +195,7 @@ app.channel('admins').leave(connection => {
 
 ### channel.filter(fn)
 
-`channel.filter(fn) -> Channel` reutrns a new channel filtered by a given function which gets passed the connection.
+`channel.filter(fn) -> Channel` returns a new channel filtered by a given function which gets passed the connection.
 
 ```js
 // Returns a new channel with all connections of the user with `_id` 5
@@ -205,13 +205,13 @@ const userFive = app.channel(app.channels)
 
 ### channel.send(data)
 
-`channel.send(data) -> Channel` returns a copy of this channel with customized data that should be sent for this event. Usually this should be handled by modifying either the service method result or setting client "safe" data in `hook.dispatch` but in some cases it might make sense to still change the event data for certain channels.
+`channel.send(data) -> Channel` returns a copy of this channel with customized data that should be sent for this event. Usually this should be handled by modifying either the service method result or setting client "safe" data in `context.dispatch` but in some cases it might make sense to still change the event data for certain channels.
 
 What data will be sent as the event data will be determined by the first available in the following order:
 
 1. `data` from `channel.send(data)`
-2. `hook.dispatch`
-3. `hook.result`
+2. `context.dispatch`
+3. `context.result`
 
 ```js
 app.on('connection', connection => {
@@ -241,7 +241,7 @@ app.service('users').publish('created', data => {
 
 ## Publishing
 
-Publishers are callback functions that return which channel(s) to send an event to. They can be registered at the application and the service level and for all or specific events. A publishing function gets the event data and hook object (`(data, hook) => {}`) and returns a named or combined channel or an array of channels. Multiple publishers can be registered. Besides the standard [service event names](./events.md#service-events) an event name can also be a [custom event](./events.md#custom-events). `hook` is the [hook object](./hooks.md) from the service call or an object containing `{ path, service, app, result }` for custom events.
+Publishers are callback functions that return which channel(s) to send an event to. They can be registered at the application and the service level and for all or specific events. A publishing function gets the event data and context object (`(data, context) => {}`) and returns a named or combined channel or an array of channels. Multiple publishers can be registered. Besides the standard [service event names](./events.md#service-events) an event name can also be a [custom event](./events.md#custom-events). `context` is the [context object](./hooks.md) from the service call or an object containing `{ path, service, app, result }` for custom events.
 
 ### service.publish([event,] fn)
 
@@ -257,12 +257,12 @@ app.on('login', (user, { connection }) => {
 });
 
 // Publish all messages service events only to its room channel
-app.service('messages').publish((data, hook) => {
+app.service('messages').publish((data, context) => {
   return app.channel(`rooms/${data.roomId}`);
 });
 
 // Publish the `created` event only to admins
-app.service('users').publish('created', (data, hook) => {
+app.service('users').publish('created', (data, context) => {
   return app.channel('admins');
 });
 ```
@@ -281,12 +281,12 @@ app.on('login', (user, { connection }) => {
 });
 
 // Publish all events to all authenticated users
-app.publish((data, hook) => {
+app.publish((data, context) => {
   return app.channel('authenticated');
 });
 
 // Publish the `log` custom event to all connections
-app.publish('log', (data, hook) => {
+app.publish('log', (data, context) => {
   return app.channel(app.channels);
 });
 ```

--- a/api/databases/common.md
+++ b/api/databases/common.md
@@ -256,11 +256,11 @@ const app = feathers()
 app.service('todos').hooks({
   before: {
     create: [
-      (hook) => hook.data.createdAt = new Date()
+      (context) => context.data.createdAt = new Date()
     ],
     
     update: [
-      (hook) => hook.data.updatedAt = new Date()
+      (context) => context.data.updatedAt = new Date()
     ]
   }
 });

--- a/api/databases/knexjs.md
+++ b/api/databases/knexjs.md
@@ -231,7 +231,7 @@ At the start of any request, a new transaction will be started. All the changes 
 
 The object that contains `transaction` is stored in the `params.transaction` of each request.
 
-> __Important:__ If you call another Knex service within a hook and want to share the transaction you will have to pass `hook.params.transaction` in the parameters of the service call.
+> __Important:__ If you call another Knex service within a hook and want to share the transaction you will have to pass `context.params.transaction` in the parameters of the service call.
 
 
 ## Customizing the query
@@ -243,13 +243,13 @@ Combined with `.createQuery({ query: {...} })`, which returns a new KnexJS query
 ```js
 app.service('mesages').hooks({
   before: {
-    find(hook) {
-      const query = this.createQuery({ query: hook.params.query });
+    find(context) {
+      const query = this.createQuery({ query: context.params.query });
 
       // do something with query here
       query.orderBy('name', 'desc');
 
-      hook.params.knex = query;
+      context.params.knex = query;
     }
   }
 });

--- a/api/databases/mongodb.md
+++ b/api/databases/mongodb.md
@@ -122,8 +122,8 @@ const ObjectID = require('mongodb').ObjectID;
 
 app.service('users').hooks({
   before: {
-    find(hook) {
-      const { query = {} } = hook.params;
+    find(context) {
+      const { query = {} } = context.params;
 
       if(query._id) {
         query._id  = new ObjectID(query._id);
@@ -133,9 +133,9 @@ app.service('users').hooks({
         query.age = parseInt(query.age, 10);
       }
 
-      hook.params.query = query;
+      context.params.query = query;
 
-      return Promise.resolve(hook);
+      return Promise.resolve(context);
     }
   }
 });

--- a/api/databases/mongoose.md
+++ b/api/databases/mongoose.md
@@ -64,11 +64,11 @@ When making a [service method](../services.md) call, `params` can contain a `mon
 ```js
 app.service('messages').hooks({
   before: {
-    patch(hook) {
+    patch(context) {
       // Set some additional Mongoose options
       // The adapter tries to use sane defaults
       // but they can always be changed here
-      hook.params.mongoose = {
+      context.params.mongoose = {
         runValidators: true,
         setDefaultsOnInsert: true
       }

--- a/api/databases/rethinkdb.md
+++ b/api/databases/rethinkdb.md
@@ -200,14 +200,14 @@ Combined with `.createQuery(query)`, which returns a new RethinkDB query with th
 ```js
 app.service('mesages').hooks({
   before: {
-    find(hook) {
-      const query = this.createQuery(hook.params.query);
+    find(context) {
+      const query = this.createQuery(context.params.query);
       const r = this.options.r;
 
       const point = r.point(-122.422876, 37.777128);  // San Francisco
 
       // Update the query with an additional `getNearest` condition
-      hook.params.rethinkdb = query.getNearest(point, { index: 'location' });
+      context.params.rethinkdb = query.getNearest(point, { index: 'location' });
     }
   }
 });

--- a/api/databases/sequelize.md
+++ b/api/databases/sequelize.md
@@ -64,11 +64,11 @@ When making a [service method](./services.md) call, `params` can contain an `seq
 ```js
 app.service('messages').hooks({
   before: {
-    find(hook) {
+    find(context) {
       // Get the Sequelize instance. In the generated application via:
-      const sequelize = hook.app.get('sequelizeClient');
+      const sequelize = context.app.get('sequelizeClient');
       
-      hook.params.sequelize = {
+      context.params.sequelize = {
         include: [ User ]
       }
     }
@@ -165,10 +165,10 @@ It is highly recommended to use `raw` queries, which is the default. However, th
 
 1. Set `{ raw: false }` in a "before" hook:
     ```js
-    function rawFalse(hook) {
-        if (!hook.params.sequelize) hook.params.sequelize = {};
-        Object.assign(hook.params.sequelize, { raw: false });
-        return hook;
+    function rawFalse(context) {
+        if (!context.params.sequelize) context.params.sequelize = {};
+        Object.assign(context.params.sequelize, { raw: false });
+        return context;
     }
     hooks.before.find = [rawFalse];
     ```
@@ -179,10 +179,10 @@ It is highly recommended to use `raw` queries, which is the default. However, th
     hooks.after.find = [hydrate()];
     
     // Or, if you need to include associated models, you can do the following:
-     function includeAssociated (hook) {
+     function includeAssociated (context) {
          return hydrate({
-            include: [{ model: hook.app.services.fooservice.Model }]
-         }).call(this, hook);
+            include: [{ model: context.app.services.fooservice.Model }]
+         }).call(this, context);
      }
      hooks.after.find = [includeAssociated];
      ```

--- a/api/events.md
+++ b/api/events.md
@@ -45,7 +45,7 @@ Any service automaticaly emits `created`, `updated`, `patched` and `removed` eve
 
 > **ProTip:** Events are not fired until all of your [hooks](./hooks.md) have executed.
 
-> **Important:** For information how those events are published for real-time updates to connected clients, see the [channel chapter](./channels.md).
+> **Important:** For information on how those events are published for real-time updates to connected clients, see the [channel chapter](./channels.md).
 
 ### created
 

--- a/api/express.md
+++ b/api/express.md
@@ -214,9 +214,9 @@ For any [service method call](./services.md) made through REST `params.provider`
 ```js
 app.service('users').hooks({
   before: {
-    remove(hook) {
-      // check for if(hook.params.provider) to prevent any external call
-      if(hook.params.provider === 'rest') {
+    remove(context) {
+      // check for if(context.params.provider) to prevent any external call
+      if(context.params.provider === 'rest') {
         throw new Error('You can not delete a user via REST');
       }
     }

--- a/api/hooks.md
+++ b/api/hooks.md
@@ -42,8 +42,8 @@ app.service('messages').hooks({
 
 A hook function can be a normal or `async` function or arrow function that takes the [hook context](#hook-context) as the parameter and can
 
+- return a `context` object
 - return nothing (`undefined`)
-- return the `context` object
 - `throw` an error
 - for asynchronous operations return a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that
   - resolves with a `context` object
@@ -90,8 +90,8 @@ The following example throws an error when the text for creating a new message i
 app.service('messages').hooks({
   before: {
     create: [
-      function(hook) {
-        if(hook.data.text.trim() === '') {
+      function(context) {
+        if(context.data.text.trim() === '') {
           throw new Error('Message text can not be empty');
         }
       }
@@ -108,7 +108,7 @@ The hook `context` is passed to a hook function and contains information about t
 
 ### context.app
 
-`context.app` is a _read only_ property that contains the [Feathers application object](./application.md). This can be used to retrieve other services (via `hook.app.service('name')`) or configuration values.
+`context.app` is a _read only_ property that contains the [Feathers application object](./application.md). This can be used to retrieve other services (via `context.app.service('name')`) or configuration values.
 
 ### context.service
 
@@ -163,8 +163,6 @@ When the hook function is `async` or a Promise is returned it will wait until al
 
 > **Important:** As stated in the [hook functions](#hook-functions) section the promise has to either resolve with the `context` object (usually done with `.then(() => context)` at the end of the promise chain) or with `undefined`.
 
-> **Note:** A common case when 
-
 ### async/await
 
 When using Node v8.0.0 or later the use of [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) is highly recommended. This will avoid many common issues when using Promises and asynchronous hook flows. Any hook function can be `async` in which case it will wait until all `await` operations are completed. Just like a normal hook it should return the `context` object or `undefined`.
@@ -176,15 +174,15 @@ app.service('messages').hooks({
   after: {
     get: [
       async function(context) {
-        const userId = hook.result.userId;
+        const userId = context.result.userId;
 
-        // Since hook.app.service('users').get returns a promise we can `await` it
+        // Since context.app.service('users').get returns a promise we can `await` it
         const user = await context.app.service('users').get(userId);
-        
+
         // Update the result (the message)
         context.result.user = user;
 
-        // Returning will resolve the promise with the `hook` object
+        // Returning will resolve the promise with the `context` object
         return context;
       }
     ]
@@ -201,14 +199,14 @@ app.service('messages').hooks({
   after: {
     get: [
       function(context) {
-        const userId = hook.result.userId;
+        const userId = context.result.userId;
 
-        // hook.app.service('users').get returns a Promise already
+        // context.app.service('users').get returns a Promise already
         return context.app.service('users').get(userId).then(user => {
           // Update the result (the message)
           context.result.user = user;
 
-          // Returning will resolve the promise with the `hook` object
+          // Returning will resolve the promise with the `context` object
           return context;
         });
       }
@@ -260,12 +258,12 @@ app.service('servicename').hooks({
   before: {
     all: [
       // Use normal functions
-      function(hook) { console.log('before all hook ran'); }
+      function(context) { console.log('before all hook ran'); }
     ],
     find: [
       // Use ES6 arrow functions
-      hook => console.log('before find hook 1 ran'),
-      hook => console.log('before find hook 2 ran')
+      context => console.log('before find hook 1 ran'),
+      context => console.log('before find hook 2 ran')
     ],
     get: [ /* other hook functions here */ ],
     create: [],
@@ -295,13 +293,13 @@ app.service('servicename').hooks({
 
 // Register a single hook before, after and on error for all methods
 app.service('servicename').hooks({
-  before(hook) {
+  before(context) {
     console.log('before all hook ran');
   },
-  after(hook) {
+  after(context) {
     console.log('after all hook ran');
   },
-  error(hook) {
+  error(context) {
     console.log('error all hook ran');
   }
 });
@@ -310,7 +308,6 @@ app.service('servicename').hooks({
 > **Pro Tip:** When using the full object, `all` is a special keyword meaning this hook will run for all methods. `all` hooks will be registered before other method specific hooks.
 
 > **Pro Tip:** `app.service(<servicename>).hooks(hooks)` can be called multiple times and the hooks will be registered in that order. Normally all hooks should be registered at once however to see at a glance what what the service is going to do.
-
 
 ## Application hooks
 
@@ -324,8 +321,8 @@ Here is an example for a very useful application hook that logs every service me
 
 ```js
 app.hooks({
-  error(hook) {
-    console.error(`Error in '${hook.path}' service method '${hook.method}`, hook.error.stack);
+  error(context) {
+    console.error(`Error in '${context.path}' service method '${context.method}`, context.error.stack);
   }
 });
 ```

--- a/api/primus.md
+++ b/api/primus.md
@@ -56,9 +56,9 @@ For any [service method call](./services.md) made through `params.provider` will
 ```js
 app.service('users').hooks({
   before: {
-    remove(hook) {
-      // check for if(hook.params.provider) to prevent any external call
-      if(hook.params.provider === 'primus') {
+    remove(context) {
+      // check for if(context.params.provider) to prevent any external call
+      if(context.params.provider === 'primus') {
         throw new Error('You can not delete a user via Primus');
       }
     }

--- a/api/socketio.md
+++ b/api/socketio.md
@@ -112,9 +112,9 @@ For any [service method call](./services.md) made through Socket.io `params.prov
 ```js
 app.service('users').hooks({
   before: {
-    remove(hook) {
-      // check for if(hook.params.provider) to prevent any external call
-      if(hook.params.provider === 'socketio') {
+    remove(context) {
+      // check for if(context.params.provider) to prevent any external call
+      if(context.params.provider === 'socketio') {
         throw new Error('You can not delete a user via Socket.io');
       }
     }

--- a/ecosystem/readme.md
+++ b/ecosystem/readme.md
@@ -159,7 +159,7 @@ The Feathers client works with React Native but here is a collection of native l
 - [feathers-hooks-csvtoarray](https://www.npmjs.com/package/feathers-hooks-csvtoarray) - Feathers hook for converting a comma-delimited list to an Array of strings.
 - [feathers-hooks-jsonapify](https://www.npmjs.com/package/feathers-hooks-jsonapify) - Feathers hook for outputting data in a JSON-API-compliant way.
 - [feathers-populate-hook](https://www.npmjs.com/package/feathers-populate-hook) - Feathers hook to populate multiple fields with n:m, n:1 or 1:m relations. (hook)
-- [feathers-transform-hook](https://www.npmjs.com/package/feathers-transform-hook) - Feathers hook for transform hook.data parameters (hook)
+- [feathers-transform-hook](https://www.npmjs.com/package/feathers-transform-hook) - Feathers hook for transform context.data parameters (hook)
 - [feathers-virtual-attribute-hook](https://www.npmjs.com/package/feathers-virtual-attribute-hook) - Feathers hook for add virtual attributes to your service response (hook)
 
 ## Transports

--- a/examples/chat/_diff/server-finish-line.html
+++ b/examples/chat/_diff/server-finish-line.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
   <title>Diff to HTML by rtfpessoa</title>
@@ -13,349 +12,8 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/styles/github.min.css">
 
   <style>
-    .d2h-wrapper {
-      text-align: left
-    }
-
-    .d2h-file-header {
-      padding: 5px 10px;
-      border-bottom: 1px solid #d8d8d8;
-      background-color: #f7f7f7
-    }
-
-    .d2h-file-stats {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      margin-left: auto;
-      font-size: 14px
-    }
-
-    .d2h-lines-added {
-      text-align: right;
-      border: 1px solid #b4e2b4;
-      border-radius: 5px 0 0 5px;
-      color: #399839;
-      padding: 2px;
-      vertical-align: middle
-    }
-
-    .d2h-lines-deleted {
-      text-align: left;
-      border: 1px solid #e9aeae;
-      border-radius: 0 5px 5px 0;
-      color: #c33;
-      padding: 2px;
-      vertical-align: middle;
-      margin-left: 1px
-    }
-
-    .d2h-file-name-wrapper {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      -webkit-box-align: center;
-      -ms-flex-align: center;
-      align-items: center;
-      width: 100%;
-      font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
-      font-size: 15px
-    }
-
-    .d2h-file-name {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow-x: hidden;
-      line-height: 21px
-    }
-
-    .d2h-file-diff,
-    .d2h-file-side-diff {
-      overflow-x: scroll;
-      overflow-y: hidden
-    }
-
-    .d2h-file-wrapper {
-      border: 1px solid #ddd;
-      border-radius: 3px;
-      margin-bottom: 1em
-    }
-
-    .d2h-diff-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-family: Menlo, Consolas, monospace;
-      font-size: 13px
-    }
-
-    .d2h-diff-tbody>tr>td {
-      height: 20px;
-      line-height: 20px
-    }
-
-    .d2h-files-diff {
-      display: block;
-      width: 100%;
-      height: 100%
-    }
-
-    .d2h-file-side-diff {
-      display: inline-block;
-      width: 50%;
-      margin-right: -4px;
-      margin-bottom: -8px
-    }
-
-    .d2h-code-line {
-      display: inline-block;
-      white-space: nowrap;
-      padding: 0 10px;
-      margin-left: 80px
-    }
-
-    .d2h-code-side-line {
-      display: inline-block;
-      white-space: nowrap;
-      padding: 0 10px;
-      margin-left: 50px
-    }
-
-    .d2h-code-line del,
-    .d2h-code-side-line del {
-      display: inline-block;
-      margin-top: -1px;
-      text-decoration: none;
-      background-color: #ffb6ba;
-      border-radius: .2em
-    }
-
-    .d2h-code-line ins,
-    .d2h-code-side-line ins {
-      display: inline-block;
-      margin-top: -1px;
-      text-decoration: none;
-      background-color: #97f295;
-      border-radius: .2em;
-      text-align: left
-    }
-
-    .d2h-code-line-ctn,
-    .d2h-code-line-prefix {
-      display: inline;
-      background: 0 0;
-      padding: 0;
-      word-wrap: normal;
-      white-space: pre
-    }
-
-    .d2h-code-linenumber,
-    .d2h-code-side-linenumber {
-      position: absolute;
-      background-color: #fff;
-      text-align: right;
-      color: rgba(0, 0, 0, .3);
-      cursor: pointer
-    }
-
-    .line-num1,
-    .line-num2 {
-      width: 40px;
-      padding-left: 3px;
-      box-sizing: border-box;
-      overflow: hidden;
-      text-overflow: ellipsis
-    }
-
-    .line-num1 {
-      float: left
-    }
-
-    .line-num2 {
-      float: right
-    }
-
-    .d2h-code-linenumber {
-      box-sizing: border-box;
-      width: 86px;
-      padding-left: 2px;
-      padding-right: 2px;
-      border: solid #eee;
-      border-width: 0 1px
-    }
-
-    .d2h-code-side-linenumber {
-      box-sizing: border-box;
-      width: 56px;
-      padding-left: 5px;
-      padding-right: 5px;
-      border: solid #eee;
-      border-width: 0 1px;
-      overflow: hidden;
-      text-overflow: ellipsis
-    }
-
-    .d2h-del {
-      background-color: #fee8e9;
-      border-color: #e9aeae
-    }
-
-    .d2h-ins {
-      background-color: #dfd;
-      border-color: #b4e2b4
-    }
-
-    .d2h-info {
-      background-color: #f8fafd;
-      color: rgba(0, 0, 0, .3);
-      border-color: #d5e4f2
-    }
-
-    .d2h-file-diff .d2h-del.d2h-change {
-      background-color: #fdf2d0
-    }
-
-    .d2h-file-diff .d2h-ins.d2h-change {
-      background-color: #ded
-    }
-
-    .d2h-file-list-wrapper {
-      margin-bottom: 10px
-    }
-
-    .d2h-file-list-wrapper a {
-      text-decoration: none;
-      color: #3572b0
-    }
-
-    .d2h-file-list-wrapper a:visited {
-      color: #3572b0
-    }
-
-    .d2h-file-list-header {
-      text-align: left
-    }
-
-    .d2h-file-list-title {
-      font-weight: 700
-    }
-
-    .d2h-file-list-line {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      text-align: left
-    }
-
-    .d2h-file-list {
-      display: block;
-      list-style: none;
-      padding: 0;
-      margin: 0
-    }
-
-    .d2h-file-list>li {
-      border-bottom: #ddd solid 1px;
-      padding: 5px 10px;
-      margin: 0
-    }
-
-    .d2h-file-list>li:last-child {
-      border-bottom: none
-    }
-
-    .d2h-file-switch {
-      display: none;
-      font-size: 10px;
-      cursor: pointer
-    }
-
-    .d2h-icon-wrapper {
-      line-height: 31px
-    }
-
-    .d2h-icon {
-      vertical-align: middle;
-      margin-right: 10px;
-      fill: currentColor
-    }
-
-    .d2h-deleted {
-      color: #c33
-    }
-
-    .d2h-added {
-      color: #399839
-    }
-
-    .d2h-changed {
-      color: #d0b44c
-    }
-
-    .d2h-moved {
-      color: #3572b0
-    }
-
-    .d2h-tag {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      font-size: 10px;
-      margin-left: 5px;
-      padding: 0 2px;
-      background-color: #fff
-    }
-
-    .d2h-deleted-tag {
-      border: 1px solid #c33
-    }
-
-    .d2h-added-tag {
-      border: 1px solid #399839
-    }
-
-    .d2h-changed-tag {
-      border: 1px solid #d0b44c
-    }
-
-    .d2h-moved-tag {
-      border: 1px solid #3572b0
-    }
-
-    .selecting-left .d2h-code-line,
-    .selecting-left .d2h-code-line *,
-    .selecting-left .d2h-code-side-line,
-    .selecting-left .d2h-code-side-line *,
-    .selecting-right td.d2h-code-linenumber,
-    .selecting-right td.d2h-code-linenumber *,
-    .selecting-right td.d2h-code-side-linenumber,
-    .selecting-right td.d2h-code-side-linenumber * {
-      -webkit-touch-callout: none;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none
-    }
-
-    .selecting-left .d2h-code-line ::-moz-selection,
-    .selecting-left .d2h-code-line::-moz-selection,
-    .selecting-left .d2h-code-side-line ::-moz-selection,
-    .selecting-left .d2h-code-side-line::-moz-selection,
-    .selecting-right td.d2h-code-linenumber::-moz-selection,
-    .selecting-right td.d2h-code-side-linenumber ::-moz-selection,
-    .selecting-right td.d2h-code-side-linenumber::-moz-selection {
-      background: 0 0
-    }
-
-    .selecting-left .d2h-code-line ::selection,
-    .selecting-left .d2h-code-line::selection,
-    .selecting-left .d2h-code-side-line ::selection,
-    .selecting-left .d2h-code-side-line::selection,
-    .selecting-right td.d2h-code-linenumber::selection,
-    .selecting-right td.d2h-code-side-linenumber ::selection,
-    .selecting-right td.d2h-code-side-linenumber::selection {
-      background: 0 0
-    }
-  </style>
+.d2h-wrapper{text-align:left}.d2h-file-header{padding:5px 10px;border-bottom:1px solid #d8d8d8;background-color:#f7f7f7}.d2h-file-stats{display:-webkit-box;display:-ms-flexbox;display:flex;margin-left:auto;font-size:14px}.d2h-lines-added{text-align:right;border:1px solid #b4e2b4;border-radius:5px 0 0 5px;color:#399839;padding:2px;vertical-align:middle}.d2h-lines-deleted{text-align:left;border:1px solid #e9aeae;border-radius:0 5px 5px 0;color:#c33;padding:2px;vertical-align:middle;margin-left:1px}.d2h-file-name-wrapper{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;width:100%;font-family:"Source Sans Pro","Helvetica Neue",Helvetica,Arial,sans-serif;font-size:15px}.d2h-file-name{white-space:nowrap;text-overflow:ellipsis;overflow-x:hidden;line-height:21px}.d2h-file-diff,.d2h-file-side-diff{overflow-x:scroll;overflow-y:hidden}.d2h-file-wrapper{border:1px solid #ddd;border-radius:3px;margin-bottom:1em}.d2h-diff-table{width:100%;border-collapse:collapse;font-family:Menlo,Consolas,monospace;font-size:13px}.d2h-diff-tbody>tr>td{height:20px;line-height:20px}.d2h-files-diff{display:block;width:100%;height:100%}.d2h-file-side-diff{display:inline-block;width:50%;margin-right:-4px;margin-bottom:-8px}.d2h-code-line{display:inline-block;white-space:nowrap;padding:0 10px;margin-left:80px}.d2h-code-side-line{display:inline-block;white-space:nowrap;padding:0 10px;margin-left:50px}.d2h-code-line del,.d2h-code-side-line del{display:inline-block;margin-top:-1px;text-decoration:none;background-color:#ffb6ba;border-radius:.2em}.d2h-code-line ins,.d2h-code-side-line ins{display:inline-block;margin-top:-1px;text-decoration:none;background-color:#97f295;border-radius:.2em;text-align:left}.d2h-code-line-ctn,.d2h-code-line-prefix{display:inline;background:0 0;padding:0;word-wrap:normal;white-space:pre}.d2h-code-linenumber,.d2h-code-side-linenumber{position:absolute;background-color:#fff;text-align:right;color:rgba(0,0,0,.3);cursor:pointer}.line-num1,.line-num2{width:40px;padding-left:3px;box-sizing:border-box;overflow:hidden;text-overflow:ellipsis}.line-num1{float:left}.line-num2{float:right}.d2h-code-linenumber{box-sizing:border-box;width:86px;padding-left:2px;padding-right:2px;border:solid #eee;border-width:0 1px}.d2h-code-side-linenumber{box-sizing:border-box;width:56px;padding-left:5px;padding-right:5px;border:solid #eee;border-width:0 1px;overflow:hidden;text-overflow:ellipsis}.d2h-del{background-color:#fee8e9;border-color:#e9aeae}.d2h-ins{background-color:#dfd;border-color:#b4e2b4}.d2h-info{background-color:#f8fafd;color:rgba(0,0,0,.3);border-color:#d5e4f2}.d2h-file-diff .d2h-del.d2h-change{background-color:#fdf2d0}.d2h-file-diff .d2h-ins.d2h-change{background-color:#ded}.d2h-file-list-wrapper{margin-bottom:10px}.d2h-file-list-wrapper a{text-decoration:none;color:#3572b0}.d2h-file-list-wrapper a:visited{color:#3572b0}.d2h-file-list-header{text-align:left}.d2h-file-list-title{font-weight:700}.d2h-file-list-line{display:-webkit-box;display:-ms-flexbox;display:flex;text-align:left}.d2h-file-list{display:block;list-style:none;padding:0;margin:0}.d2h-file-list>li{border-bottom:#ddd solid 1px;padding:5px 10px;margin:0}.d2h-file-list>li:last-child{border-bottom:none}.d2h-file-switch{display:none;font-size:10px;cursor:pointer}.d2h-icon-wrapper{line-height:31px}.d2h-icon{vertical-align:middle;margin-right:10px;fill:currentColor}.d2h-deleted{color:#c33}.d2h-added{color:#399839}.d2h-changed{color:#d0b44c}.d2h-moved{color:#3572b0}.d2h-tag{display:-webkit-box;display:-ms-flexbox;display:flex;font-size:10px;margin-left:5px;padding:0 2px;background-color:#fff}.d2h-deleted-tag{border:1px solid #c33}.d2h-added-tag{border:1px solid #399839}.d2h-changed-tag{border:1px solid #d0b44c}.d2h-moved-tag{border:1px solid #3572b0}.selecting-left .d2h-code-line,.selecting-left .d2h-code-line *,.selecting-left .d2h-code-side-line,.selecting-left .d2h-code-side-line *,.selecting-right td.d2h-code-linenumber,.selecting-right td.d2h-code-linenumber *,.selecting-right td.d2h-code-side-linenumber,.selecting-right td.d2h-code-side-linenumber *{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.selecting-left .d2h-code-line ::-moz-selection,.selecting-left .d2h-code-line::-moz-selection,.selecting-left .d2h-code-side-line ::-moz-selection,.selecting-left .d2h-code-side-line::-moz-selection,.selecting-right td.d2h-code-linenumber::-moz-selection,.selecting-right td.d2h-code-side-linenumber ::-moz-selection,.selecting-right td.d2h-code-side-linenumber::-moz-selection{background:0 0}.selecting-left .d2h-code-line ::selection,.selecting-left .d2h-code-line::selection,.selecting-left .d2h-code-side-line ::selection,.selecting-left .d2h-code-side-line::selection,.selecting-right td.d2h-code-linenumber::selection,.selecting-right td.d2h-code-side-linenumber ::selection,.selecting-right td.d2h-code-side-linenumber::selection{background:0 0}
+</style>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
 
@@ -363,720 +21,629 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/scala.min.js"></script>
 
   <script>
-    !function e(t, n, r) { function s(o, u) { if (!n[o]) { if (!t[o]) { var a = "function" == typeof require && require; if (!u && a) return a(o, !0); if (i) return i(o, !0); var f = new Error("Cannot find module '" + o + "'"); throw f.code = "MODULE_NOT_FOUND", f } var l = n[o] = { exports: {} }; t[o][0].call(l.exports, function (e) { var n = t[o][1][e]; return s(n ? n : e) }, l, l.exports, e, t, n, r) } return n[o].exports } for (var i = "function" == typeof require && require, o = 0; o < r.length; o++)s(r[o]); return s }({ 1: [function (require, module) { (function (global) { !function () { function Diff2HtmlUI(config) { var cfg = config || {}; cfg.diff ? diffJson = Diff2Html.getJsonFromDiff(cfg.diff) : cfg.json && (diffJson = cfg.json), this._initSelection() } function synchronisedScroll($target, config) { config.synchronisedScroll && $target.find(".d2h-file-side-diff").scroll(function () { var $this = $(this); $this.closest(".d2h-file-wrapper").find(".d2h-file-side-diff").scrollLeft($this.scrollLeft()) }) } var highlightJS = require("./highlight.js-internals.js").HighlightJS, diffJson = null, defaultTarget = "body", currentSelectionColumnId = -1; Diff2HtmlUI.prototype.draw = function (targetId, config) { var cfg = config || {}; cfg.inputFormat = "json"; var $target = this._getTarget(targetId); $target.html(Diff2Html.getPrettyHtml(diffJson, cfg)), synchronisedScroll($target, cfg) }, Diff2HtmlUI.prototype.fileListCloseable = function (targetId, startVisible) { function show() { $showBtn.hide(), $hideBtn.show(), $fileList.show() } function hide() { $hideBtn.hide(), $showBtn.show(), $fileList.hide() } var $target = this._getTarget(targetId), hashTag = this._getHashTag(), $showBtn = $target.find(".d2h-show"), $hideBtn = $target.find(".d2h-hide"), $fileList = $target.find(".d2h-file-list"); "files-summary-show" === hashTag ? show() : "files-summary-hide" === hashTag ? hide() : startVisible ? show() : hide(), $showBtn.click(show), $hideBtn.click(hide) }, Diff2HtmlUI.prototype.highlightCode = function (targetId) { var that = this, $target = that._getTarget(targetId), $files = $target.find(".d2h-file-wrapper"); $files.map(function (_i, file) { var oldLinesState, newLinesState, $file = $(file), language = $file.data("lang"), $codeLines = $file.find(".d2h-code-line-ctn"); $codeLines.map(function (_j, line) { var lineState, $line = $(line), text = line.textContent, lineParent = line.parentNode; lineState = -1 !== lineParent.className.indexOf("d2h-del") ? oldLinesState : newLinesState; var result = hljs.getLanguage(language) ? hljs.highlight(language, text, !0, lineState) : hljs.highlightAuto(text); -1 !== lineParent.className.indexOf("d2h-del") ? oldLinesState = result.top : -1 !== lineParent.className.indexOf("d2h-ins") ? newLinesState = result.top : (oldLinesState = result.top, newLinesState = result.top); var originalStream = highlightJS.nodeStream(line); if (originalStream.length) { var resultNode = document.createElementNS("http://www.w3.org/1999/xhtml", "div"); resultNode.innerHTML = result.value, result.value = highlightJS.mergeStreams(originalStream, highlightJS.nodeStream(resultNode), text) } $line.addClass("hljs"), $line.addClass(result.language), $line.html(result.value) }) }) }, Diff2HtmlUI.prototype._getTarget = function (targetId) { var $target; return "object" == typeof targetId && targetId instanceof jQuery ? $target = targetId : "string" == typeof targetId ? $target = $(targetId) : (console.error("Wrong target provided! Falling back to default value 'body'."), console.log("Please provide a jQuery object or a valid DOM query string."), $target = $(defaultTarget)), $target }, Diff2HtmlUI.prototype._getHashTag = function () { var docUrl = document.URL, hashTagIndex = docUrl.indexOf("#"), hashTag = null; return -1 !== hashTagIndex && (hashTag = docUrl.substr(hashTagIndex + 1)), hashTag }, Diff2HtmlUI.prototype._distinct = function (collection) { return collection.filter(function (v, i) { return collection.indexOf(v) === i }) }, Diff2HtmlUI.prototype._initSelection = function () { var body = $("body"), that = this; body.on("mousedown", ".d2h-diff-table", function (event) { var target = $(event.target), table = target.closest(".d2h-diff-table"); target.closest(".d2h-code-line,.d2h-code-side-line").length ? (table.removeClass("selecting-left"), table.addClass("selecting-right"), currentSelectionColumnId = 1) : target.closest(".d2h-code-linenumber,.d2h-code-side-linenumber").length && (table.removeClass("selecting-right"), table.addClass("selecting-left"), currentSelectionColumnId = 0) }), body.on("copy", ".d2h-diff-table", function (event) { var clipboardData = event.originalEvent.clipboardData, text = that._getSelectedText(); clipboardData.setData("text", text), event.preventDefault() }) }, Diff2HtmlUI.prototype._getSelectedText = function () { var sel = window.getSelection(), range = sel.getRangeAt(0), doc = range.cloneContents(), nodes = doc.querySelectorAll("tr"), text = "", idx = currentSelectionColumnId; return 0 === nodes.length ? text = doc.textContent : [].forEach.call(nodes, function (tr, i) { var td = tr.cells[1 === tr.cells.length ? 0 : idx]; text += (i ? "\n" : "") + td.textContent.replace(/(?:\r\n|\r|\n)/g, "") }), text }, module.exports.Diff2HtmlUI = Diff2HtmlUI, global.Diff2HtmlUI = Diff2HtmlUI }() }).call(this, "undefined" != typeof global ? global : "undefined" != typeof self ? self : "undefined" != typeof window ? window : {}) }, { "./highlight.js-internals.js": 2 }], 2: [function (require, module) { !function () { function HighlightJS() { } function escape(value) { return value.replace(/&/gm, "&amp;").replace(/</gm, "&lt;").replace(/>/gm, "&gt;") } function tag(node) { return node.nodeName.toLowerCase() } HighlightJS.prototype.nodeStream = function (node) { var result = []; return function _nodeStream(node, offset) { for (var child = node.firstChild; child; child = child.nextSibling)3 === child.nodeType ? offset += child.nodeValue.length : 1 === child.nodeType && (result.push({ event: "start", offset: offset, node: child }), offset = _nodeStream(child, offset), tag(child).match(/br|hr|img|input/) || result.push({ event: "stop", offset: offset, node: child })); return offset }(node, 0), result }, HighlightJS.prototype.mergeStreams = function (original, highlighted, value) { function selectStream() { return original.length && highlighted.length ? original[0].offset !== highlighted[0].offset ? original[0].offset < highlighted[0].offset ? original : highlighted : "start" === highlighted[0].event ? original : highlighted : original.length ? original : highlighted } function open(node) { function attrStr(a) { return " " + a.nodeName + '="' + escape(a.value) + '"' } result += "<" + tag(node) + Array.prototype.map.call(node.attributes, attrStr).join("") + ">" } function close(node) { result += "</" + tag(node) + ">" } function render(event) { ("start" === event.event ? open : close)(event.node) } for (var processed = 0, result = "", nodeStack = []; original.length || highlighted.length;) { var stream = selectStream(); if (result += escape(value.substr(processed, stream[0].offset - processed)), processed = stream[0].offset, stream === original) { nodeStack.reverse().forEach(close); do render(stream.splice(0, 1)[0]), stream = selectStream(); while (stream === original && stream.length && stream[0].offset === processed); nodeStack.reverse().forEach(open) } else "start" === stream[0].event ? nodeStack.push(stream[0].node) : nodeStack.pop(), render(stream.splice(0, 1)[0]) } return result + escape(value.substr(processed)) }, module.exports.HighlightJS = new HighlightJS }() }, {}] }, {}, [1]);
-  </script>
+!function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a="function"==typeof require&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}for(var i="function"==typeof require&&require,o=0;o<r.length;o++)s(r[o]);return s}({1:[function(require,module){(function(global){!function(){function Diff2HtmlUI(config){var cfg=config||{};cfg.diff?diffJson=Diff2Html.getJsonFromDiff(cfg.diff):cfg.json&&(diffJson=cfg.json),this._initSelection()}function synchronisedScroll($target,config){config.synchronisedScroll&&$target.find(".d2h-file-side-diff").scroll(function(){var $this=$(this);$this.closest(".d2h-file-wrapper").find(".d2h-file-side-diff").scrollLeft($this.scrollLeft())})}var highlightJS=require("./highlight.js-internals.js").HighlightJS,diffJson=null,defaultTarget="body",currentSelectionColumnId=-1;Diff2HtmlUI.prototype.draw=function(targetId,config){var cfg=config||{};cfg.inputFormat="json";var $target=this._getTarget(targetId);$target.html(Diff2Html.getPrettyHtml(diffJson,cfg)),synchronisedScroll($target,cfg)},Diff2HtmlUI.prototype.fileListCloseable=function(targetId,startVisible){function show(){$showBtn.hide(),$hideBtn.show(),$fileList.show()}function hide(){$hideBtn.hide(),$showBtn.show(),$fileList.hide()}var $target=this._getTarget(targetId),hashTag=this._getHashTag(),$showBtn=$target.find(".d2h-show"),$hideBtn=$target.find(".d2h-hide"),$fileList=$target.find(".d2h-file-list");"files-summary-show"===hashTag?show():"files-summary-hide"===hashTag?hide():startVisible?show():hide(),$showBtn.click(show),$hideBtn.click(hide)},Diff2HtmlUI.prototype.highlightCode=function(targetId){var that=this,$target=that._getTarget(targetId),$files=$target.find(".d2h-file-wrapper");$files.map(function(_i,file){var oldLinesState,newLinesState,$file=$(file),language=$file.data("lang"),$codeLines=$file.find(".d2h-code-line-ctn");$codeLines.map(function(_j,line){var lineState,$line=$(line),text=line.textContent,lineParent=line.parentNode;lineState=-1!==lineParent.className.indexOf("d2h-del")?oldLinesState:newLinesState;var result=hljs.getLanguage(language)?hljs.highlight(language,text,!0,lineState):hljs.highlightAuto(text);-1!==lineParent.className.indexOf("d2h-del")?oldLinesState=result.top:-1!==lineParent.className.indexOf("d2h-ins")?newLinesState=result.top:(oldLinesState=result.top,newLinesState=result.top);var originalStream=highlightJS.nodeStream(line);if(originalStream.length){var resultNode=document.createElementNS("http://www.w3.org/1999/xhtml","div");resultNode.innerHTML=result.value,result.value=highlightJS.mergeStreams(originalStream,highlightJS.nodeStream(resultNode),text)}$line.addClass("hljs"),$line.addClass(result.language),$line.html(result.value)})})},Diff2HtmlUI.prototype._getTarget=function(targetId){var $target;return"object"==typeof targetId&&targetId instanceof jQuery?$target=targetId:"string"==typeof targetId?$target=$(targetId):(console.error("Wrong target provided! Falling back to default value 'body'."),console.log("Please provide a jQuery object or a valid DOM query string."),$target=$(defaultTarget)),$target},Diff2HtmlUI.prototype._getHashTag=function(){var docUrl=document.URL,hashTagIndex=docUrl.indexOf("#"),hashTag=null;return-1!==hashTagIndex&&(hashTag=docUrl.substr(hashTagIndex+1)),hashTag},Diff2HtmlUI.prototype._distinct=function(collection){return collection.filter(function(v,i){return collection.indexOf(v)===i})},Diff2HtmlUI.prototype._initSelection=function(){var body=$("body"),that=this;body.on("mousedown",".d2h-diff-table",function(event){var target=$(event.target),table=target.closest(".d2h-diff-table");target.closest(".d2h-code-line,.d2h-code-side-line").length?(table.removeClass("selecting-left"),table.addClass("selecting-right"),currentSelectionColumnId=1):target.closest(".d2h-code-linenumber,.d2h-code-side-linenumber").length&&(table.removeClass("selecting-right"),table.addClass("selecting-left"),currentSelectionColumnId=0)}),body.on("copy",".d2h-diff-table",function(event){var clipboardData=event.originalEvent.clipboardData,text=that._getSelectedText();clipboardData.setData("text",text),event.preventDefault()})},Diff2HtmlUI.prototype._getSelectedText=function(){var sel=window.getSelection(),range=sel.getRangeAt(0),doc=range.cloneContents(),nodes=doc.querySelectorAll("tr"),text="",idx=currentSelectionColumnId;return 0===nodes.length?text=doc.textContent:[].forEach.call(nodes,function(tr,i){var td=tr.cells[1===tr.cells.length?0:idx];text+=(i?"\n":"")+td.textContent.replace(/(?:\r\n|\r|\n)/g,"")}),text},module.exports.Diff2HtmlUI=Diff2HtmlUI,global.Diff2HtmlUI=Diff2HtmlUI}()}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{"./highlight.js-internals.js":2}],2:[function(require,module){!function(){function HighlightJS(){}function escape(value){return value.replace(/&/gm,"&amp;").replace(/</gm,"&lt;").replace(/>/gm,"&gt;")}function tag(node){return node.nodeName.toLowerCase()}HighlightJS.prototype.nodeStream=function(node){var result=[];return function _nodeStream(node,offset){for(var child=node.firstChild;child;child=child.nextSibling)3===child.nodeType?offset+=child.nodeValue.length:1===child.nodeType&&(result.push({event:"start",offset:offset,node:child}),offset=_nodeStream(child,offset),tag(child).match(/br|hr|img|input/)||result.push({event:"stop",offset:offset,node:child}));return offset}(node,0),result},HighlightJS.prototype.mergeStreams=function(original,highlighted,value){function selectStream(){return original.length&&highlighted.length?original[0].offset!==highlighted[0].offset?original[0].offset<highlighted[0].offset?original:highlighted:"start"===highlighted[0].event?original:highlighted:original.length?original:highlighted}function open(node){function attrStr(a){return" "+a.nodeName+'="'+escape(a.value)+'"'}result+="<"+tag(node)+Array.prototype.map.call(node.attributes,attrStr).join("")+">"}function close(node){result+="</"+tag(node)+">"}function render(event){("start"===event.event?open:close)(event.node)}for(var processed=0,result="",nodeStack=[];original.length||highlighted.length;){var stream=selectStream();if(result+=escape(value.substr(processed,stream[0].offset-processed)),processed=stream[0].offset,stream===original){nodeStack.reverse().forEach(close);do render(stream.splice(0,1)[0]),stream=selectStream();while(stream===original&&stream.length&&stream[0].offset===processed);nodeStack.reverse().forEach(open)}else"start"===stream[0].event?nodeStack.push(stream[0].node):nodeStack.pop(),render(stream.splice(0,1)[0])}return result+escape(value.substr(processed))},module.exports.HighlightJS=new HighlightJS}()},{}]},{},[1]);
+</script>
 
   <script>
-    $(document).ready(function () {
+    $(document).ready(function() {
       var diff2htmlUi = new Diff2HtmlUI();
       diff2htmlUi.fileListCloseable("#diff", undefined);
       diff2htmlUi.highlightCode('#diff');
     });
   </script>
 </head>
-
 <body style="text-align: center; font-family: 'Source Sans Pro',sans-serif;">
-  <h1>Diff to HTML by
-    <a href="https://github.com/rtfpessoa">rtfpessoa</a>
-  </h1>
+<h1>Diff to HTML by <a href="https://github.com/rtfpessoa">rtfpessoa</a></h1>
 
-  <div id="diff">
-    <div class="d2h-wrapper">
-      <div id="d2h-713428" class="d2h-file-wrapper" data-lang="848000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/index.js 2017-01-01 15:22:15.104000000 -0500 → finish/src/services/message/hooks/index.js
-              2017-01-15 15:14:05.848000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-file-diff">
-          <div class="d2h-code-wrapper">
+<div id="diff">
+  <div class="d2h-wrapper">
+    <div id="d2h-713428" class="d2h-file-wrapper" data-lang="848000000 -0500">
+    <div class="d2h-file-header">
+    <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/index.js	2017-01-01 15:22:15.104000000 -0500 → finish/src/services/message/hooks/index.js	2017-01-15 15:14:05.848000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-file-diff">
+        <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
-              <tbody class="d2h-diff-tbody">
+                <tbody class="d2h-diff-tbody">
                 <tr>
-                  <td class="d2h-code-linenumber d2h-info"></td>
-                  <td class="d2h-info">
-                    <div class="d2h-code-line d2h-info">@@ -4,6 +4,28 @@</div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">4</div>
-                    <div class="line-num2">4</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn">const hooks = require('feathers-hooks');</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">5</div>
-                    <div class="line-num2">5</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn">const auth = require('feathers-authentication').hooks;</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">6</div>
-                    <div class="line-num2">6</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">7</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const restrictToSender = require('./restrict-to-sender');</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">8</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const process = require('./process');</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">9</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const { setCreatedAt, populate, dePopulate, serialize } = require('feathers-hooks-common');</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">10</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">11</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const restrictToSenderOrServer = when(isProvider('external'), restrictToSender());</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">12</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">13</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const populateSchema = {</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">14</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> include: [{</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">15</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> service: 'users',</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">16</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> nameAs: 'sentBy',</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">17</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> parentField: 'userId',</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">18</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> childField: '_id'</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">19</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> }]</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">20</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">};</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">21</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">22</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">const serializeSchema = {</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">23</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> only: [ '_id', 'text', 'createdAt' ],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">24</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> sentBy: {</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">25</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> only: [ 'email', 'avatar' ]</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">26</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> }</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">27</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn">};</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">28</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">7</div>
-                    <div class="line-num2">29</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn">exports.before = {</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">8</div>
-                    <div class="line-num2">30</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> all: [</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">9</div>
-                    <div class="line-num2">31</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> auth.verifyToken(),</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-info"></td>
-                  <td class="d2h-info">
-                    <div class="d2h-code-line d2h-info">@@ -12,17 +34,17 @@</div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">12</div>
-                    <div class="line-num2">34</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> ],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">13</div>
-                    <div class="line-num2">35</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> find: [],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">14</div>
-                    <div class="line-num2">36</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> get: [],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">15</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> create:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">16</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> update:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">17</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> patch:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">18</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> remove:
-                        <del>[]</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">37</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> create:
-                        <ins>[ process(), setCreatedAt() ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">38</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> update:
-                        <ins>[ dePopulate(), restrictToSender() ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">39</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> patch:
-                        <ins>[ dePopulate(), restrictToSender() ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">40</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> remove:
-                        <ins>[ restrictToSenderOrServer ]</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">19</div>
-                    <div class="line-num2">41</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn">};</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">20</div>
-                    <div class="line-num2">42</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">21</div>
-                    <div class="line-num2">43</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn">exports.after = {</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">22</div>
-                    <div class="line-num2">44</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> all: [],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">23</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> find:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">24</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> get:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-del">
-                    <div class="line-num1">25</div>
-                    <div class="line-num2"></div>
-                  </td>
-                  <td class="d2h-del">
-                    <div class="d2h-code-line d2h-del">
-                      <span class="d2h-code-line-prefix">-</span>
-                      <span class="d2h-code-line-ctn"> create:
-                        <del>[],</del>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">45</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> find:
-                        <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">46</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> get:
-                        <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-ins">
-                    <div class="line-num1"></div>
-                    <div class="line-num2">47</div>
-                  </td>
-                  <td class="d2h-ins">
-                    <div class="d2h-code-line d2h-ins">
-                      <span class="d2h-code-line-prefix">+</span>
-                      <span class="d2h-code-line-ctn"> create:
-                        <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">26</div>
-                    <div class="line-num2">48</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> update: [],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">27</div>
-                    <div class="line-num2">49</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> patch: [],</span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="d2h-code-linenumber d2h-cntx">
-                    <div class="line-num1">28</div>
-                    <div class="line-num2">50</div>
-                  </td>
-                  <td class="d2h-cntx">
-                    <div class="d2h-code-line d2h-cntx">
-                      <span class="d2h-code-line-prefix"> </span>
-                      <span class="d2h-code-line-ctn"> remove: []</span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
+    <td class="d2h-code-linenumber d2h-info"></td>
+    <td class="d2h-info">
+        <div class="d2h-code-line d2h-info">@@ -4,6 +4,28 @@</div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">4</div>
+<div class="line-num2">4</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">const hooks = require('feathers-hooks');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">5</div>
+<div class="line-num2">5</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">const auth = require('feathers-authentication').hooks;</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">6</div>
+<div class="line-num2">6</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">7</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const restrictToSender = require('./restrict-to-sender');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">8</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const process = require('./process');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">9</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const { setCreatedAt, populate, dePopulate, serialize } = require('feathers-hooks-common');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">10</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">11</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const restrictToSenderOrServer = when(isProvider('external'), restrictToSender());</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">12</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">13</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const populateSchema = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">14</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  include: [{</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">15</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    service: 'users',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">16</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    nameAs: 'sentBy',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">17</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    parentField: 'userId',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">18</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    childField: '_id'</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">19</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  }]</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">20</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">21</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">22</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const serializeSchema = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">23</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  only: [ '_id', 'text', 'createdAt' ],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">24</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  sentBy: {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">25</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    only: [ 'email', 'avatar' ]</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">26</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  }</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">27</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">28</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">7</div>
+<div class="line-num2">29</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">exports.before = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">8</div>
+<div class="line-num2">30</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  all: [</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">9</div>
+<div class="line-num2">31</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">    auth.verifyToken(),</span>
+        </div>
+    </td>
+</tr>
+<tr>
+    <td class="d2h-code-linenumber d2h-info"></td>
+    <td class="d2h-info">
+        <div class="d2h-code-line d2h-info">@@ -12,17 +34,17 @@</div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">12</div>
+<div class="line-num2">34</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  ],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">13</div>
+<div class="line-num2">35</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  find: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">14</div>
+<div class="line-num2">36</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  get: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">15</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  create: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">16</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  update: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">17</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  patch: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">18</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  remove: <del>[]</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">37</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  create: <ins>[ process(), setCreatedAt() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">38</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  update: <ins>[ dePopulate(), restrictToSender() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">39</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  patch: <ins>[ dePopulate(), restrictToSender() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">40</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  remove: <ins>[ restrictToSenderOrServer ]</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">19</div>
+<div class="line-num2">41</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">20</div>
+<div class="line-num2">42</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">21</div>
+<div class="line-num2">43</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">exports.after = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">22</div>
+<div class="line-num2">44</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  all: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">23</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  find: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">24</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  get: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-del">
+      <div class="line-num1">25</div>
+<div class="line-num2"></div>
+    </td>
+    <td class="d2h-del">
+        <div class="d2h-code-line d2h-del">
+            <span class="d2h-code-line-prefix">-</span>
+            <span class="d2h-code-line-ctn">  create: <del>[],</del></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">45</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  find: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">46</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  get: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-ins">
+      <div class="line-num1"></div>
+<div class="line-num2">47</div>
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  create: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">26</div>
+<div class="line-num2">48</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  update: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">27</div>
+<div class="line-num2">49</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  patch: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-linenumber d2h-cntx">
+      <div class="line-num1">28</div>
+<div class="line-num2">50</div>
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  remove: []</span>
+        </div>
+    </td>
+</tr>
+                </tbody>
             </table>
-          </div>
         </div>
-      </div>
-      <div id="d2h-154219" class="d2h-file-wrapper" data-lang="930000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/process.js 1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/process.js
-              2017-01-03 11:12:35.930000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-file-diff">
-          <div class="d2h-code-wrapper">
+    </div>
+</div>
+<div id="d2h-154219" class="d2h-file-wrapper" data-lang="930000000 -0500">
+    <div class="d2h-file-header">
+    <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/process.js	1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/process.js	2017-01-03 11:12:35.930000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-file-diff">
+        <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
                 <tbody class="d2h-diff-tbody">
                 <tr>
@@ -1250,24 +817,20 @@
 </tr>
                 </tbody>
             </table>
-          </div>
         </div>
-      </div>
-      <div id="d2h-185000" class="d2h-file-wrapper" data-lang="918000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/restrict-to-sender.js 1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/restrict-to-sender.js
-              2017-01-01 16:00:47.918000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-file-diff">
-          <div class="d2h-code-wrapper">
+    </div>
+</div>
+<div id="d2h-185000" class="d2h-file-wrapper" data-lang="918000000 -0500">
+    <div class="d2h-file-header">
+    <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/restrict-to-sender.js	1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/restrict-to-sender.js	2017-01-01 16:00:47.918000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-file-diff">
+        <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
                 <tbody class="d2h-diff-tbody">
                 <tr>
@@ -1550,24 +1113,20 @@
 </tr>
                 </tbody>
             </table>
-          </div>
         </div>
-      </div>
-      <div id="d2h-933848" class="d2h-file-wrapper" data-lang="086000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/test/services/message/hooks/process.test.js 1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/process.test.js
-              2017-01-01 13:38:18.086000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-file-diff">
-          <div class="d2h-code-wrapper">
+    </div>
+</div>
+<div id="d2h-933848" class="d2h-file-wrapper" data-lang="086000000 -0500">
+    <div class="d2h-file-header">
+    <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/test/services/message/hooks/process.test.js	1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/process.test.js	2017-01-01 13:38:18.086000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-file-diff">
+        <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
                 <tbody class="d2h-diff-tbody">
                 <tr>
@@ -1794,24 +1353,20 @@
 </tr>
                 </tbody>
             </table>
-          </div>
         </div>
-      </div>
-      <div id="d2h-793450" class="d2h-file-wrapper" data-lang="014000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/test/services/message/hooks/restrict-to-sender.test.js 1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/restrict-to-sender.test.js
-              2017-01-01 15:56:40.014000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-file-diff">
-          <div class="d2h-code-wrapper">
+    </div>
+</div>
+<div id="d2h-793450" class="d2h-file-wrapper" data-lang="014000000 -0500">
+    <div class="d2h-file-header">
+    <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/test/services/message/hooks/restrict-to-sender.test.js	1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/restrict-to-sender.test.js	2017-01-01 15:56:40.014000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-file-diff">
+        <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
                 <tbody class="d2h-diff-tbody">
                 <tr>
@@ -2038,11 +1593,10 @@
 </tr>
                 </tbody>
             </table>
-          </div>
         </div>
-      </div>
     </div>
-  </div>
+</div>
+</div>
+</div>
 </body>
-
 </html>

--- a/examples/chat/_diff/server-finish-line.html
+++ b/examples/chat/_diff/server-finish-line.html
@@ -734,7 +734,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = () =&gt; hook =&gt; {</span>
+            <span class="d2h-code-line-ctn">module.exports = () =&gt; context =&gt; {</span>
         </div>
     </td>
 </tr><tr>
@@ -745,7 +745,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  hook.data.text = hook.data.text</span>
+            <span class="d2h-code-line-ctn">  context.data.text = context.data.text</span>
         </div>
     </td>
 </tr><tr>
@@ -778,7 +778,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  hook.data.userId = hook.params.user._id; // Add the authenticated user _id</span>
+            <span class="d2h-code-line-ctn">  context.data.userId = context.params.user._id; // Add the authenticated user _id</span>
         </div>
     </td>
 </tr><tr>
@@ -800,7 +800,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return hook;</span>
+            <span class="d2h-code-line-ctn">  return context;</span>
         </div>
     </td>
 </tr><tr>
@@ -953,7 +953,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return function(hook) {</span>
+            <span class="d2h-code-line-ctn">  return function(context) {</span>
         </div>
     </td>
 </tr><tr>
@@ -964,7 +964,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const messageService = hook.app.service('messages');</span>
+            <span class="d2h-code-line-ctn">    const messageService = context.app.service('messages');</span>
         </div>
     </td>
 </tr><tr>
@@ -997,7 +997,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    return messageService.get(hook.id, hook.params).then(message =&gt; {</span>
+            <span class="d2h-code-line-ctn">    return messageService.get(context.id, context.params).then(message =&gt; {</span>
         </div>
     </td>
 </tr><tr>
@@ -1019,7 +1019,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      if (message.sentBy._id !== hook.params.user._id &amp;&amp; hook.provider) {</span>
+            <span class="d2h-code-line-ctn">      if (message.sentBy._id !== context.params.user._id &amp;&amp; context.provider) {</span>
         </div>
     </td>
 </tr><tr>
@@ -1063,7 +1063,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      // Otherwise just return the hook</span>
+            <span class="d2h-code-line-ctn">      // Otherwise just return the context</span>
         </div>
     </td>
 </tr><tr>
@@ -1074,7 +1074,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      return hook;</span>
+            <span class="d2h-code-line-ctn">      return context;</span>
         </div>
     </td>
 </tr><tr>
@@ -1217,7 +1217,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const mockHook = {</span>
+            <span class="d2h-code-line-ctn">    const mockContext = {</span>
         </div>
     </td>
 </tr><tr>
@@ -1304,7 +1304,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    process()(mockHook);</span>
+            <span class="d2h-code-line-ctn">    process()(mockContext);</span>
         </div>
     </td>
 </tr><tr>
@@ -1325,7 +1325,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    assert.ok(mockHook.process);</span>
+            <span class="d2h-code-line-ctn">    assert.ok(mockContext.process);</span>
         </div>
     </td>
 </tr><tr>
@@ -1457,7 +1457,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const mockHook = {</span>
+            <span class="d2h-code-line-ctn">    const mockContext = {</span>
         </div>
     </td>
 </tr><tr>
@@ -1544,7 +1544,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    restrictToSender()(mockHook);</span>
+            <span class="d2h-code-line-ctn">    restrictToSender()(mockContext);</span>
         </div>
     </td>
 </tr><tr>
@@ -1565,7 +1565,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    assert.ok(mockHook.restrictToSender);</span>
+            <span class="d2h-code-line-ctn">    assert.ok(mockContext.restrictToSender);</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/chat/_diff/server-finish-side.html
+++ b/examples/chat/_diff/server-finish-side.html
@@ -87,7 +87,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -95,7 +95,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -103,7 +103,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -111,7 +111,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -119,7 +119,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -127,7 +127,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -135,7 +135,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -143,7 +143,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -151,7 +151,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -159,7 +159,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -167,7 +167,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -175,7 +175,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -183,7 +183,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -191,7 +191,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -199,7 +199,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -207,7 +207,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -215,7 +215,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -223,7 +223,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -231,7 +231,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -239,7 +239,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -247,7 +247,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -255,7 +255,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -956,7 +956,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -964,7 +964,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -972,7 +972,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -980,7 +980,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -988,7 +988,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -996,7 +996,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1004,7 +1004,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1012,7 +1012,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1020,7 +1020,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1028,7 +1028,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1036,7 +1036,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1044,7 +1044,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1052,7 +1052,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1060,7 +1060,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1068,7 +1068,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1163,7 +1163,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = () =&gt; hook =&gt; {</span>
+            <span class="d2h-code-line-ctn">module.exports = () =&gt; context =&gt; {</span>
         </div>
     </td>
 </tr><tr>
@@ -1173,7 +1173,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  hook.data.text = hook.data.text</span>
+            <span class="d2h-code-line-ctn">  context.data.text = context.data.text</span>
         </div>
     </td>
 </tr><tr>
@@ -1203,7 +1203,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  hook.data.userId = hook.params.user._id; // Add the authenticated user _id</span>
+            <span class="d2h-code-line-ctn">  context.data.userId = context.params.user._id; // Add the authenticated user _id</span>
         </div>
     </td>
 </tr><tr>
@@ -1223,7 +1223,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return hook;</span>
+            <span class="d2h-code-line-ctn">  return context;</span>
         </div>
     </td>
 </tr><tr>
@@ -1264,7 +1264,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1272,7 +1272,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1280,7 +1280,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1288,7 +1288,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1296,7 +1296,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1304,7 +1304,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1312,7 +1312,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1320,7 +1320,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1328,7 +1328,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1336,7 +1336,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1344,7 +1344,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1352,7 +1352,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1360,7 +1360,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1368,7 +1368,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1376,7 +1376,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1384,7 +1384,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1392,7 +1392,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1400,7 +1400,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1408,7 +1408,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1416,7 +1416,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1424,7 +1424,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1432,7 +1432,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1440,7 +1440,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1448,7 +1448,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1456,7 +1456,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1580,7 +1580,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return function(hook) {</span>
+            <span class="d2h-code-line-ctn">  return function(context) {</span>
         </div>
     </td>
 </tr><tr>
@@ -1590,7 +1590,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const messageService = hook.app.service('messages');</span>
+            <span class="d2h-code-line-ctn">    const messageService = context.app.service('messages');</span>
         </div>
     </td>
 </tr><tr>
@@ -1620,7 +1620,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    return messageService.get(hook.id, hook.params).then(message =&gt; {</span>
+            <span class="d2h-code-line-ctn">    return messageService.get(context.id, context.params).then(message =&gt; {</span>
         </div>
     </td>
 </tr><tr>
@@ -1640,7 +1640,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      if (message.sentBy._id !== hook.params.user._id &amp;&amp; hook.provider) {</span>
+            <span class="d2h-code-line-ctn">      if (message.sentBy._id !== context.params.user._id &amp;&amp; context.provider) {</span>
         </div>
     </td>
 </tr><tr>
@@ -1680,7 +1680,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      // Otherwise just return the hook</span>
+            <span class="d2h-code-line-ctn">      // Otherwise just return the context</span>
         </div>
     </td>
 </tr><tr>
@@ -1690,7 +1690,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      return hook;</span>
+            <span class="d2h-code-line-ctn">      return context;</span>
         </div>
     </td>
 </tr><tr>
@@ -1751,7 +1751,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1759,7 +1759,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1767,7 +1767,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1775,7 +1775,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1783,7 +1783,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1791,7 +1791,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1799,7 +1799,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1807,7 +1807,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1815,7 +1815,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1823,7 +1823,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1831,7 +1831,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1839,7 +1839,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1847,7 +1847,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1855,7 +1855,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1863,7 +1863,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1871,7 +1871,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1879,7 +1879,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1887,7 +1887,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1895,7 +1895,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1903,7 +1903,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1998,7 +1998,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const mockHook = {</span>
+            <span class="d2h-code-line-ctn">    const mockContext = {</span>
         </div>
     </td>
 </tr><tr>
@@ -2077,7 +2077,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    process()(mockHook);</span>
+            <span class="d2h-code-line-ctn">    process()(mockContext);</span>
         </div>
     </td>
 </tr><tr>
@@ -2096,7 +2096,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    assert.ok(mockHook.process);</span>
+            <span class="d2h-code-line-ctn">    assert.ok(mockContext.process);</span>
         </div>
     </td>
 </tr><tr>
@@ -2147,7 +2147,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2155,7 +2155,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2163,7 +2163,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2171,7 +2171,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2179,7 +2179,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2187,7 +2187,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2195,7 +2195,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2203,7 +2203,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2211,7 +2211,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2219,7 +2219,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2227,7 +2227,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2235,7 +2235,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2243,7 +2243,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2251,7 +2251,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2259,7 +2259,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2267,7 +2267,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2275,7 +2275,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2283,7 +2283,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2291,7 +2291,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2299,7 +2299,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2394,7 +2394,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    const mockHook = {</span>
+            <span class="d2h-code-line-ctn">    const mockContext = {</span>
         </div>
     </td>
 </tr><tr>
@@ -2473,7 +2473,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    restrictToSender()(mockHook);</span>
+            <span class="d2h-code-line-ctn">    restrictToSender()(mockContext);</span>
         </div>
     </td>
 </tr><tr>
@@ -2492,7 +2492,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    assert.ok(mockHook.restrictToSender);</span>
+            <span class="d2h-code-line-ctn">    assert.ok(mockContext.restrictToSender);</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/chat/_diff/server-finish-side.html
+++ b/examples/chat/_diff/server-finish-side.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
   <title>Diff to HTML by rtfpessoa</title>
@@ -13,349 +12,8 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/styles/github.min.css">
 
   <style>
-    .d2h-wrapper {
-      text-align: left
-    }
-
-    .d2h-file-header {
-      padding: 5px 10px;
-      border-bottom: 1px solid #d8d8d8;
-      background-color: #f7f7f7
-    }
-
-    .d2h-file-stats {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      margin-left: auto;
-      font-size: 14px
-    }
-
-    .d2h-lines-added {
-      text-align: right;
-      border: 1px solid #b4e2b4;
-      border-radius: 5px 0 0 5px;
-      color: #399839;
-      padding: 2px;
-      vertical-align: middle
-    }
-
-    .d2h-lines-deleted {
-      text-align: left;
-      border: 1px solid #e9aeae;
-      border-radius: 0 5px 5px 0;
-      color: #c33;
-      padding: 2px;
-      vertical-align: middle;
-      margin-left: 1px
-    }
-
-    .d2h-file-name-wrapper {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      -webkit-box-align: center;
-      -ms-flex-align: center;
-      align-items: center;
-      width: 100%;
-      font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
-      font-size: 15px
-    }
-
-    .d2h-file-name {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow-x: hidden;
-      line-height: 21px
-    }
-
-    .d2h-file-diff,
-    .d2h-file-side-diff {
-      overflow-x: scroll;
-      overflow-y: hidden
-    }
-
-    .d2h-file-wrapper {
-      border: 1px solid #ddd;
-      border-radius: 3px;
-      margin-bottom: 1em
-    }
-
-    .d2h-diff-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-family: Menlo, Consolas, monospace;
-      font-size: 13px
-    }
-
-    .d2h-diff-tbody>tr>td {
-      height: 20px;
-      line-height: 20px
-    }
-
-    .d2h-files-diff {
-      display: block;
-      width: 100%;
-      height: 100%
-    }
-
-    .d2h-file-side-diff {
-      display: inline-block;
-      width: 50%;
-      margin-right: -4px;
-      margin-bottom: -8px
-    }
-
-    .d2h-code-line {
-      display: inline-block;
-      white-space: nowrap;
-      padding: 0 10px;
-      margin-left: 80px
-    }
-
-    .d2h-code-side-line {
-      display: inline-block;
-      white-space: nowrap;
-      padding: 0 10px;
-      margin-left: 50px
-    }
-
-    .d2h-code-line del,
-    .d2h-code-side-line del {
-      display: inline-block;
-      margin-top: -1px;
-      text-decoration: none;
-      background-color: #ffb6ba;
-      border-radius: .2em
-    }
-
-    .d2h-code-line ins,
-    .d2h-code-side-line ins {
-      display: inline-block;
-      margin-top: -1px;
-      text-decoration: none;
-      background-color: #97f295;
-      border-radius: .2em;
-      text-align: left
-    }
-
-    .d2h-code-line-ctn,
-    .d2h-code-line-prefix {
-      display: inline;
-      background: 0 0;
-      padding: 0;
-      word-wrap: normal;
-      white-space: pre
-    }
-
-    .d2h-code-linenumber,
-    .d2h-code-side-linenumber {
-      position: absolute;
-      background-color: #fff;
-      text-align: right;
-      color: rgba(0, 0, 0, .3);
-      cursor: pointer
-    }
-
-    .line-num1,
-    .line-num2 {
-      width: 40px;
-      padding-left: 3px;
-      box-sizing: border-box;
-      overflow: hidden;
-      text-overflow: ellipsis
-    }
-
-    .line-num1 {
-      float: left
-    }
-
-    .line-num2 {
-      float: right
-    }
-
-    .d2h-code-linenumber {
-      box-sizing: border-box;
-      width: 86px;
-      padding-left: 2px;
-      padding-right: 2px;
-      border: solid #eee;
-      border-width: 0 1px
-    }
-
-    .d2h-code-side-linenumber {
-      box-sizing: border-box;
-      width: 56px;
-      padding-left: 5px;
-      padding-right: 5px;
-      border: solid #eee;
-      border-width: 0 1px;
-      overflow: hidden;
-      text-overflow: ellipsis
-    }
-
-    .d2h-del {
-      background-color: #fee8e9;
-      border-color: #e9aeae
-    }
-
-    .d2h-ins {
-      background-color: #dfd;
-      border-color: #b4e2b4
-    }
-
-    .d2h-info {
-      background-color: #f8fafd;
-      color: rgba(0, 0, 0, .3);
-      border-color: #d5e4f2
-    }
-
-    .d2h-file-diff .d2h-del.d2h-change {
-      background-color: #fdf2d0
-    }
-
-    .d2h-file-diff .d2h-ins.d2h-change {
-      background-color: #ded
-    }
-
-    .d2h-file-list-wrapper {
-      margin-bottom: 10px
-    }
-
-    .d2h-file-list-wrapper a {
-      text-decoration: none;
-      color: #3572b0
-    }
-
-    .d2h-file-list-wrapper a:visited {
-      color: #3572b0
-    }
-
-    .d2h-file-list-header {
-      text-align: left
-    }
-
-    .d2h-file-list-title {
-      font-weight: 700
-    }
-
-    .d2h-file-list-line {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      text-align: left
-    }
-
-    .d2h-file-list {
-      display: block;
-      list-style: none;
-      padding: 0;
-      margin: 0
-    }
-
-    .d2h-file-list>li {
-      border-bottom: #ddd solid 1px;
-      padding: 5px 10px;
-      margin: 0
-    }
-
-    .d2h-file-list>li:last-child {
-      border-bottom: none
-    }
-
-    .d2h-file-switch {
-      display: none;
-      font-size: 10px;
-      cursor: pointer
-    }
-
-    .d2h-icon-wrapper {
-      line-height: 31px
-    }
-
-    .d2h-icon {
-      vertical-align: middle;
-      margin-right: 10px;
-      fill: currentColor
-    }
-
-    .d2h-deleted {
-      color: #c33
-    }
-
-    .d2h-added {
-      color: #399839
-    }
-
-    .d2h-changed {
-      color: #d0b44c
-    }
-
-    .d2h-moved {
-      color: #3572b0
-    }
-
-    .d2h-tag {
-      display: -webkit-box;
-      display: -ms-flexbox;
-      display: flex;
-      font-size: 10px;
-      margin-left: 5px;
-      padding: 0 2px;
-      background-color: #fff
-    }
-
-    .d2h-deleted-tag {
-      border: 1px solid #c33
-    }
-
-    .d2h-added-tag {
-      border: 1px solid #399839
-    }
-
-    .d2h-changed-tag {
-      border: 1px solid #d0b44c
-    }
-
-    .d2h-moved-tag {
-      border: 1px solid #3572b0
-    }
-
-    .selecting-left .d2h-code-line,
-    .selecting-left .d2h-code-line *,
-    .selecting-left .d2h-code-side-line,
-    .selecting-left .d2h-code-side-line *,
-    .selecting-right td.d2h-code-linenumber,
-    .selecting-right td.d2h-code-linenumber *,
-    .selecting-right td.d2h-code-side-linenumber,
-    .selecting-right td.d2h-code-side-linenumber * {
-      -webkit-touch-callout: none;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none
-    }
-
-    .selecting-left .d2h-code-line ::-moz-selection,
-    .selecting-left .d2h-code-line::-moz-selection,
-    .selecting-left .d2h-code-side-line ::-moz-selection,
-    .selecting-left .d2h-code-side-line::-moz-selection,
-    .selecting-right td.d2h-code-linenumber::-moz-selection,
-    .selecting-right td.d2h-code-side-linenumber ::-moz-selection,
-    .selecting-right td.d2h-code-side-linenumber::-moz-selection {
-      background: 0 0
-    }
-
-    .selecting-left .d2h-code-line ::selection,
-    .selecting-left .d2h-code-line::selection,
-    .selecting-left .d2h-code-side-line ::selection,
-    .selecting-left .d2h-code-side-line::selection,
-    .selecting-right td.d2h-code-linenumber::selection,
-    .selecting-right td.d2h-code-side-linenumber ::selection,
-    .selecting-right td.d2h-code-side-linenumber::selection {
-      background: 0 0
-    }
-  </style>
+.d2h-wrapper{text-align:left}.d2h-file-header{padding:5px 10px;border-bottom:1px solid #d8d8d8;background-color:#f7f7f7}.d2h-file-stats{display:-webkit-box;display:-ms-flexbox;display:flex;margin-left:auto;font-size:14px}.d2h-lines-added{text-align:right;border:1px solid #b4e2b4;border-radius:5px 0 0 5px;color:#399839;padding:2px;vertical-align:middle}.d2h-lines-deleted{text-align:left;border:1px solid #e9aeae;border-radius:0 5px 5px 0;color:#c33;padding:2px;vertical-align:middle;margin-left:1px}.d2h-file-name-wrapper{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;width:100%;font-family:"Source Sans Pro","Helvetica Neue",Helvetica,Arial,sans-serif;font-size:15px}.d2h-file-name{white-space:nowrap;text-overflow:ellipsis;overflow-x:hidden;line-height:21px}.d2h-file-diff,.d2h-file-side-diff{overflow-x:scroll;overflow-y:hidden}.d2h-file-wrapper{border:1px solid #ddd;border-radius:3px;margin-bottom:1em}.d2h-diff-table{width:100%;border-collapse:collapse;font-family:Menlo,Consolas,monospace;font-size:13px}.d2h-diff-tbody>tr>td{height:20px;line-height:20px}.d2h-files-diff{display:block;width:100%;height:100%}.d2h-file-side-diff{display:inline-block;width:50%;margin-right:-4px;margin-bottom:-8px}.d2h-code-line{display:inline-block;white-space:nowrap;padding:0 10px;margin-left:80px}.d2h-code-side-line{display:inline-block;white-space:nowrap;padding:0 10px;margin-left:50px}.d2h-code-line del,.d2h-code-side-line del{display:inline-block;margin-top:-1px;text-decoration:none;background-color:#ffb6ba;border-radius:.2em}.d2h-code-line ins,.d2h-code-side-line ins{display:inline-block;margin-top:-1px;text-decoration:none;background-color:#97f295;border-radius:.2em;text-align:left}.d2h-code-line-ctn,.d2h-code-line-prefix{display:inline;background:0 0;padding:0;word-wrap:normal;white-space:pre}.d2h-code-linenumber,.d2h-code-side-linenumber{position:absolute;background-color:#fff;text-align:right;color:rgba(0,0,0,.3);cursor:pointer}.line-num1,.line-num2{width:40px;padding-left:3px;box-sizing:border-box;overflow:hidden;text-overflow:ellipsis}.line-num1{float:left}.line-num2{float:right}.d2h-code-linenumber{box-sizing:border-box;width:86px;padding-left:2px;padding-right:2px;border:solid #eee;border-width:0 1px}.d2h-code-side-linenumber{box-sizing:border-box;width:56px;padding-left:5px;padding-right:5px;border:solid #eee;border-width:0 1px;overflow:hidden;text-overflow:ellipsis}.d2h-del{background-color:#fee8e9;border-color:#e9aeae}.d2h-ins{background-color:#dfd;border-color:#b4e2b4}.d2h-info{background-color:#f8fafd;color:rgba(0,0,0,.3);border-color:#d5e4f2}.d2h-file-diff .d2h-del.d2h-change{background-color:#fdf2d0}.d2h-file-diff .d2h-ins.d2h-change{background-color:#ded}.d2h-file-list-wrapper{margin-bottom:10px}.d2h-file-list-wrapper a{text-decoration:none;color:#3572b0}.d2h-file-list-wrapper a:visited{color:#3572b0}.d2h-file-list-header{text-align:left}.d2h-file-list-title{font-weight:700}.d2h-file-list-line{display:-webkit-box;display:-ms-flexbox;display:flex;text-align:left}.d2h-file-list{display:block;list-style:none;padding:0;margin:0}.d2h-file-list>li{border-bottom:#ddd solid 1px;padding:5px 10px;margin:0}.d2h-file-list>li:last-child{border-bottom:none}.d2h-file-switch{display:none;font-size:10px;cursor:pointer}.d2h-icon-wrapper{line-height:31px}.d2h-icon{vertical-align:middle;margin-right:10px;fill:currentColor}.d2h-deleted{color:#c33}.d2h-added{color:#399839}.d2h-changed{color:#d0b44c}.d2h-moved{color:#3572b0}.d2h-tag{display:-webkit-box;display:-ms-flexbox;display:flex;font-size:10px;margin-left:5px;padding:0 2px;background-color:#fff}.d2h-deleted-tag{border:1px solid #c33}.d2h-added-tag{border:1px solid #399839}.d2h-changed-tag{border:1px solid #d0b44c}.d2h-moved-tag{border:1px solid #3572b0}.selecting-left .d2h-code-line,.selecting-left .d2h-code-line *,.selecting-left .d2h-code-side-line,.selecting-left .d2h-code-side-line *,.selecting-right td.d2h-code-linenumber,.selecting-right td.d2h-code-linenumber *,.selecting-right td.d2h-code-side-linenumber,.selecting-right td.d2h-code-side-linenumber *{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.selecting-left .d2h-code-line ::-moz-selection,.selecting-left .d2h-code-line::-moz-selection,.selecting-left .d2h-code-side-line ::-moz-selection,.selecting-left .d2h-code-side-line::-moz-selection,.selecting-right td.d2h-code-linenumber::-moz-selection,.selecting-right td.d2h-code-side-linenumber ::-moz-selection,.selecting-right td.d2h-code-side-linenumber::-moz-selection{background:0 0}.selecting-left .d2h-code-line ::selection,.selecting-left .d2h-code-line::selection,.selecting-left .d2h-code-side-line ::selection,.selecting-left .d2h-code-side-line::selection,.selecting-right td.d2h-code-linenumber::selection,.selecting-right td.d2h-code-side-linenumber ::selection,.selecting-right td.d2h-code-side-linenumber::selection{background:0 0}
+</style>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
 
@@ -363,40 +21,33 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/scala.min.js"></script>
 
   <script>
-    !function e(t, n, r) { function s(o, u) { if (!n[o]) { if (!t[o]) { var a = "function" == typeof require && require; if (!u && a) return a(o, !0); if (i) return i(o, !0); var f = new Error("Cannot find module '" + o + "'"); throw f.code = "MODULE_NOT_FOUND", f } var l = n[o] = { exports: {} }; t[o][0].call(l.exports, function (e) { var n = t[o][1][e]; return s(n ? n : e) }, l, l.exports, e, t, n, r) } return n[o].exports } for (var i = "function" == typeof require && require, o = 0; o < r.length; o++)s(r[o]); return s }({ 1: [function (require, module) { (function (global) { !function () { function Diff2HtmlUI(config) { var cfg = config || {}; cfg.diff ? diffJson = Diff2Html.getJsonFromDiff(cfg.diff) : cfg.json && (diffJson = cfg.json), this._initSelection() } function synchronisedScroll($target, config) { config.synchronisedScroll && $target.find(".d2h-file-side-diff").scroll(function () { var $this = $(this); $this.closest(".d2h-file-wrapper").find(".d2h-file-side-diff").scrollLeft($this.scrollLeft()) }) } var highlightJS = require("./highlight.js-internals.js").HighlightJS, diffJson = null, defaultTarget = "body", currentSelectionColumnId = -1; Diff2HtmlUI.prototype.draw = function (targetId, config) { var cfg = config || {}; cfg.inputFormat = "json"; var $target = this._getTarget(targetId); $target.html(Diff2Html.getPrettyHtml(diffJson, cfg)), synchronisedScroll($target, cfg) }, Diff2HtmlUI.prototype.fileListCloseable = function (targetId, startVisible) { function show() { $showBtn.hide(), $hideBtn.show(), $fileList.show() } function hide() { $hideBtn.hide(), $showBtn.show(), $fileList.hide() } var $target = this._getTarget(targetId), hashTag = this._getHashTag(), $showBtn = $target.find(".d2h-show"), $hideBtn = $target.find(".d2h-hide"), $fileList = $target.find(".d2h-file-list"); "files-summary-show" === hashTag ? show() : "files-summary-hide" === hashTag ? hide() : startVisible ? show() : hide(), $showBtn.click(show), $hideBtn.click(hide) }, Diff2HtmlUI.prototype.highlightCode = function (targetId) { var that = this, $target = that._getTarget(targetId), $files = $target.find(".d2h-file-wrapper"); $files.map(function (_i, file) { var oldLinesState, newLinesState, $file = $(file), language = $file.data("lang"), $codeLines = $file.find(".d2h-code-line-ctn"); $codeLines.map(function (_j, line) { var lineState, $line = $(line), text = line.textContent, lineParent = line.parentNode; lineState = -1 !== lineParent.className.indexOf("d2h-del") ? oldLinesState : newLinesState; var result = hljs.getLanguage(language) ? hljs.highlight(language, text, !0, lineState) : hljs.highlightAuto(text); -1 !== lineParent.className.indexOf("d2h-del") ? oldLinesState = result.top : -1 !== lineParent.className.indexOf("d2h-ins") ? newLinesState = result.top : (oldLinesState = result.top, newLinesState = result.top); var originalStream = highlightJS.nodeStream(line); if (originalStream.length) { var resultNode = document.createElementNS("http://www.w3.org/1999/xhtml", "div"); resultNode.innerHTML = result.value, result.value = highlightJS.mergeStreams(originalStream, highlightJS.nodeStream(resultNode), text) } $line.addClass("hljs"), $line.addClass(result.language), $line.html(result.value) }) }) }, Diff2HtmlUI.prototype._getTarget = function (targetId) { var $target; return "object" == typeof targetId && targetId instanceof jQuery ? $target = targetId : "string" == typeof targetId ? $target = $(targetId) : (console.error("Wrong target provided! Falling back to default value 'body'."), console.log("Please provide a jQuery object or a valid DOM query string."), $target = $(defaultTarget)), $target }, Diff2HtmlUI.prototype._getHashTag = function () { var docUrl = document.URL, hashTagIndex = docUrl.indexOf("#"), hashTag = null; return -1 !== hashTagIndex && (hashTag = docUrl.substr(hashTagIndex + 1)), hashTag }, Diff2HtmlUI.prototype._distinct = function (collection) { return collection.filter(function (v, i) { return collection.indexOf(v) === i }) }, Diff2HtmlUI.prototype._initSelection = function () { var body = $("body"), that = this; body.on("mousedown", ".d2h-diff-table", function (event) { var target = $(event.target), table = target.closest(".d2h-diff-table"); target.closest(".d2h-code-line,.d2h-code-side-line").length ? (table.removeClass("selecting-left"), table.addClass("selecting-right"), currentSelectionColumnId = 1) : target.closest(".d2h-code-linenumber,.d2h-code-side-linenumber").length && (table.removeClass("selecting-right"), table.addClass("selecting-left"), currentSelectionColumnId = 0) }), body.on("copy", ".d2h-diff-table", function (event) { var clipboardData = event.originalEvent.clipboardData, text = that._getSelectedText(); clipboardData.setData("text", text), event.preventDefault() }) }, Diff2HtmlUI.prototype._getSelectedText = function () { var sel = window.getSelection(), range = sel.getRangeAt(0), doc = range.cloneContents(), nodes = doc.querySelectorAll("tr"), text = "", idx = currentSelectionColumnId; return 0 === nodes.length ? text = doc.textContent : [].forEach.call(nodes, function (tr, i) { var td = tr.cells[1 === tr.cells.length ? 0 : idx]; text += (i ? "\n" : "") + td.textContent.replace(/(?:\r\n|\r|\n)/g, "") }), text }, module.exports.Diff2HtmlUI = Diff2HtmlUI, global.Diff2HtmlUI = Diff2HtmlUI }() }).call(this, "undefined" != typeof global ? global : "undefined" != typeof self ? self : "undefined" != typeof window ? window : {}) }, { "./highlight.js-internals.js": 2 }], 2: [function (require, module) { !function () { function HighlightJS() { } function escape(value) { return value.replace(/&/gm, "&amp;").replace(/</gm, "&lt;").replace(/>/gm, "&gt;") } function tag(node) { return node.nodeName.toLowerCase() } HighlightJS.prototype.nodeStream = function (node) { var result = []; return function _nodeStream(node, offset) { for (var child = node.firstChild; child; child = child.nextSibling)3 === child.nodeType ? offset += child.nodeValue.length : 1 === child.nodeType && (result.push({ event: "start", offset: offset, node: child }), offset = _nodeStream(child, offset), tag(child).match(/br|hr|img|input/) || result.push({ event: "stop", offset: offset, node: child })); return offset }(node, 0), result }, HighlightJS.prototype.mergeStreams = function (original, highlighted, value) { function selectStream() { return original.length && highlighted.length ? original[0].offset !== highlighted[0].offset ? original[0].offset < highlighted[0].offset ? original : highlighted : "start" === highlighted[0].event ? original : highlighted : original.length ? original : highlighted } function open(node) { function attrStr(a) { return " " + a.nodeName + '="' + escape(a.value) + '"' } result += "<" + tag(node) + Array.prototype.map.call(node.attributes, attrStr).join("") + ">" } function close(node) { result += "</" + tag(node) + ">" } function render(event) { ("start" === event.event ? open : close)(event.node) } for (var processed = 0, result = "", nodeStack = []; original.length || highlighted.length;) { var stream = selectStream(); if (result += escape(value.substr(processed, stream[0].offset - processed)), processed = stream[0].offset, stream === original) { nodeStack.reverse().forEach(close); do render(stream.splice(0, 1)[0]), stream = selectStream(); while (stream === original && stream.length && stream[0].offset === processed); nodeStack.reverse().forEach(open) } else "start" === stream[0].event ? nodeStack.push(stream[0].node) : nodeStack.pop(), render(stream.splice(0, 1)[0]) } return result + escape(value.substr(processed)) }, module.exports.HighlightJS = new HighlightJS }() }, {}] }, {}, [1]);
-  </script>
+!function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a="function"==typeof require&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}for(var i="function"==typeof require&&require,o=0;o<r.length;o++)s(r[o]);return s}({1:[function(require,module){(function(global){!function(){function Diff2HtmlUI(config){var cfg=config||{};cfg.diff?diffJson=Diff2Html.getJsonFromDiff(cfg.diff):cfg.json&&(diffJson=cfg.json),this._initSelection()}function synchronisedScroll($target,config){config.synchronisedScroll&&$target.find(".d2h-file-side-diff").scroll(function(){var $this=$(this);$this.closest(".d2h-file-wrapper").find(".d2h-file-side-diff").scrollLeft($this.scrollLeft())})}var highlightJS=require("./highlight.js-internals.js").HighlightJS,diffJson=null,defaultTarget="body",currentSelectionColumnId=-1;Diff2HtmlUI.prototype.draw=function(targetId,config){var cfg=config||{};cfg.inputFormat="json";var $target=this._getTarget(targetId);$target.html(Diff2Html.getPrettyHtml(diffJson,cfg)),synchronisedScroll($target,cfg)},Diff2HtmlUI.prototype.fileListCloseable=function(targetId,startVisible){function show(){$showBtn.hide(),$hideBtn.show(),$fileList.show()}function hide(){$hideBtn.hide(),$showBtn.show(),$fileList.hide()}var $target=this._getTarget(targetId),hashTag=this._getHashTag(),$showBtn=$target.find(".d2h-show"),$hideBtn=$target.find(".d2h-hide"),$fileList=$target.find(".d2h-file-list");"files-summary-show"===hashTag?show():"files-summary-hide"===hashTag?hide():startVisible?show():hide(),$showBtn.click(show),$hideBtn.click(hide)},Diff2HtmlUI.prototype.highlightCode=function(targetId){var that=this,$target=that._getTarget(targetId),$files=$target.find(".d2h-file-wrapper");$files.map(function(_i,file){var oldLinesState,newLinesState,$file=$(file),language=$file.data("lang"),$codeLines=$file.find(".d2h-code-line-ctn");$codeLines.map(function(_j,line){var lineState,$line=$(line),text=line.textContent,lineParent=line.parentNode;lineState=-1!==lineParent.className.indexOf("d2h-del")?oldLinesState:newLinesState;var result=hljs.getLanguage(language)?hljs.highlight(language,text,!0,lineState):hljs.highlightAuto(text);-1!==lineParent.className.indexOf("d2h-del")?oldLinesState=result.top:-1!==lineParent.className.indexOf("d2h-ins")?newLinesState=result.top:(oldLinesState=result.top,newLinesState=result.top);var originalStream=highlightJS.nodeStream(line);if(originalStream.length){var resultNode=document.createElementNS("http://www.w3.org/1999/xhtml","div");resultNode.innerHTML=result.value,result.value=highlightJS.mergeStreams(originalStream,highlightJS.nodeStream(resultNode),text)}$line.addClass("hljs"),$line.addClass(result.language),$line.html(result.value)})})},Diff2HtmlUI.prototype._getTarget=function(targetId){var $target;return"object"==typeof targetId&&targetId instanceof jQuery?$target=targetId:"string"==typeof targetId?$target=$(targetId):(console.error("Wrong target provided! Falling back to default value 'body'."),console.log("Please provide a jQuery object or a valid DOM query string."),$target=$(defaultTarget)),$target},Diff2HtmlUI.prototype._getHashTag=function(){var docUrl=document.URL,hashTagIndex=docUrl.indexOf("#"),hashTag=null;return-1!==hashTagIndex&&(hashTag=docUrl.substr(hashTagIndex+1)),hashTag},Diff2HtmlUI.prototype._distinct=function(collection){return collection.filter(function(v,i){return collection.indexOf(v)===i})},Diff2HtmlUI.prototype._initSelection=function(){var body=$("body"),that=this;body.on("mousedown",".d2h-diff-table",function(event){var target=$(event.target),table=target.closest(".d2h-diff-table");target.closest(".d2h-code-line,.d2h-code-side-line").length?(table.removeClass("selecting-left"),table.addClass("selecting-right"),currentSelectionColumnId=1):target.closest(".d2h-code-linenumber,.d2h-code-side-linenumber").length&&(table.removeClass("selecting-right"),table.addClass("selecting-left"),currentSelectionColumnId=0)}),body.on("copy",".d2h-diff-table",function(event){var clipboardData=event.originalEvent.clipboardData,text=that._getSelectedText();clipboardData.setData("text",text),event.preventDefault()})},Diff2HtmlUI.prototype._getSelectedText=function(){var sel=window.getSelection(),range=sel.getRangeAt(0),doc=range.cloneContents(),nodes=doc.querySelectorAll("tr"),text="",idx=currentSelectionColumnId;return 0===nodes.length?text=doc.textContent:[].forEach.call(nodes,function(tr,i){var td=tr.cells[1===tr.cells.length?0:idx];text+=(i?"\n":"")+td.textContent.replace(/(?:\r\n|\r|\n)/g,"")}),text},module.exports.Diff2HtmlUI=Diff2HtmlUI,global.Diff2HtmlUI=Diff2HtmlUI}()}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{"./highlight.js-internals.js":2}],2:[function(require,module){!function(){function HighlightJS(){}function escape(value){return value.replace(/&/gm,"&amp;").replace(/</gm,"&lt;").replace(/>/gm,"&gt;")}function tag(node){return node.nodeName.toLowerCase()}HighlightJS.prototype.nodeStream=function(node){var result=[];return function _nodeStream(node,offset){for(var child=node.firstChild;child;child=child.nextSibling)3===child.nodeType?offset+=child.nodeValue.length:1===child.nodeType&&(result.push({event:"start",offset:offset,node:child}),offset=_nodeStream(child,offset),tag(child).match(/br|hr|img|input/)||result.push({event:"stop",offset:offset,node:child}));return offset}(node,0),result},HighlightJS.prototype.mergeStreams=function(original,highlighted,value){function selectStream(){return original.length&&highlighted.length?original[0].offset!==highlighted[0].offset?original[0].offset<highlighted[0].offset?original:highlighted:"start"===highlighted[0].event?original:highlighted:original.length?original:highlighted}function open(node){function attrStr(a){return" "+a.nodeName+'="'+escape(a.value)+'"'}result+="<"+tag(node)+Array.prototype.map.call(node.attributes,attrStr).join("")+">"}function close(node){result+="</"+tag(node)+">"}function render(event){("start"===event.event?open:close)(event.node)}for(var processed=0,result="",nodeStack=[];original.length||highlighted.length;){var stream=selectStream();if(result+=escape(value.substr(processed,stream[0].offset-processed)),processed=stream[0].offset,stream===original){nodeStack.reverse().forEach(close);do render(stream.splice(0,1)[0]),stream=selectStream();while(stream===original&&stream.length&&stream[0].offset===processed);nodeStack.reverse().forEach(open)}else"start"===stream[0].event?nodeStack.push(stream[0].node):nodeStack.pop(),render(stream.splice(0,1)[0])}return result+escape(value.substr(processed))},module.exports.HighlightJS=new HighlightJS}()},{}]},{},[1]);
+</script>
 
   <script>
-    $(document).ready(function () {
+    $(document).ready(function() {
       var diff2htmlUi = new Diff2HtmlUI();
       diff2htmlUi.fileListCloseable("#diff", undefined);
       diff2htmlUi.highlightCode('#diff');
     });
   </script>
 </head>
-
 <body style="text-align: center; font-family: 'Source Sans Pro',sans-serif;">
-  <h1>Diff to HTML by
-    <a href="https://github.com/rtfpessoa">rtfpessoa</a>
-  </h1>
+<h1>Diff to HTML by <a href="https://github.com/rtfpessoa">rtfpessoa</a></h1>
 
-  <div id="diff">
-    <div class="d2h-wrapper">
-      <div id="d2h-713428" class="d2h-file-wrapper" data-lang="848000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/index.js 2017-01-01 15:22:15.104000000 -0500 → finish/src/services/message/hooks/index.js
-              2017-01-15 15:14:05.848000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-files-diff">
-          <div class="d2h-file-side-diff">
+<div id="diff">
+  <div class="d2h-wrapper">
+    <div id="d2h-713428" class="d2h-file-wrapper" data-lang="848000000 -0500">
+    <div class="d2h-file-header">
+      <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/index.js	2017-01-01 15:22:15.104000000 -0500 → finish/src/services/message/hooks/index.js	2017-01-15 15:14:05.848000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-files-diff">
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -818,547 +469,483 @@
                     </tbody>
                 </table>
             </div>
-          </div>
-          <div class="d2h-file-side-diff">
+        </div>
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
-              <table class="d2h-diff-table">
-                <tbody class="d2h-diff-tbody">
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-info"></td>
-                    <td class="d2h-info">
-                      <div class="d2h-code-side-line d2h-info"></div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      4
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn">const hooks = require('feathers-hooks');</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      5
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn">const auth = require('feathers-authentication').hooks;</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      6
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      7
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const restrictToSender = require('./restrict-to-sender');</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      8
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const process = require('./process');</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      9
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const { setCreatedAt, populate, dePopulate, serialize } = require('feathers-hooks-common');</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      10
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      11
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const restrictToSenderOrServer = when(isProvider('external'), restrictToSender());</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      12
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      13
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const populateSchema = {</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      14
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> include: [{</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      15
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> service: 'users',</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      16
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> nameAs: 'sentBy',</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      17
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> parentField: 'userId',</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      18
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> childField: '_id'</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      19
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> }]</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      20
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">};</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      21
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      22
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">const serializeSchema = {</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      23
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> only: [ '_id', 'text', 'createdAt' ],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      24
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> sentBy: {</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      25
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> only: [ 'email', 'avatar' ]</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      26
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> }</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      27
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn">};</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      28
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      29
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn">exports.before = {</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      30
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> all: [</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      31
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> auth.verifyToken(),</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-info"></td>
-                    <td class="d2h-info">
-                      <div class="d2h-code-side-line d2h-info"></div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      34
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> ],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      35
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> find: [],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      36
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> get: [],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      37
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> create:
-                          <ins>[ process(), setCreatedAt() ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      38
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> update:
-                          <ins>[ dePopulate(), restrictToSender() ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      39
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> patch:
-                          <ins>[ dePopulate(), restrictToSender() ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      40
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> remove:
-                          <ins>[ restrictToSenderOrServer ]</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      41
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn">};</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      42
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      43
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn">exports.after = {</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      44
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> all: [],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      45
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> find:
-                          <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      46
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> get:
-                          <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-ins">
-                      47
-                    </td>
-                    <td class="d2h-ins">
-                      <div class="d2h-code-side-line d2h-ins">
-                        <span class="d2h-code-line-prefix">+</span>
-                        <span class="d2h-code-line-ctn"> create:
-                          <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      48
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> update: [],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      49
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> patch: [],</span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="d2h-code-side-linenumber d2h-cntx">
-                      50
-                    </td>
-                    <td class="d2h-cntx">
-                      <div class="d2h-code-side-line d2h-cntx">
-                        <span class="d2h-code-line-prefix"> </span>
-                        <span class="d2h-code-line-ctn"> remove: []</span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+                <table class="d2h-diff-table">
+                    <tbody class="d2h-diff-tbody">
+                    <tr>
+    <td class="d2h-code-side-linenumber d2h-info"></td>
+    <td class="d2h-info">
+        <div class="d2h-code-side-line d2h-info"></div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      4
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">const hooks = require('feathers-hooks');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      5
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">const auth = require('feathers-authentication').hooks;</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      6
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      7
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const restrictToSender = require('./restrict-to-sender');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      8
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const process = require('./process');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      9
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const { setCreatedAt, populate, dePopulate, serialize } = require('feathers-hooks-common');</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      10
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      11
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const restrictToSenderOrServer = when(isProvider('external'), restrictToSender());</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      12
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      13
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const populateSchema = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      14
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  include: [{</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      15
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    service: 'users',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      16
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    nameAs: 'sentBy',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      17
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    parentField: 'userId',</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      18
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    childField: '_id'</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      19
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  }]</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      20
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      21
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      22
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">const serializeSchema = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      23
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  only: [ '_id', 'text', 'createdAt' ],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      24
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  sentBy: {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      25
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">    only: [ 'email', 'avatar' ]</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      26
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  }</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      27
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      28
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      29
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">exports.before = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      30
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  all: [</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      31
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">    auth.verifyToken(),</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-info"></td>
+    <td class="d2h-info">
+        <div class="d2h-code-side-line d2h-info"></div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      34
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  ],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      35
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  find: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      36
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  get: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      37
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  create: <ins>[ process(), setCreatedAt() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      38
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  update: <ins>[ dePopulate(), restrictToSender() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      39
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  patch: <ins>[ dePopulate(), restrictToSender() ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      40
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  remove: <ins>[ restrictToSenderOrServer ]</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      41
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">};</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      42
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      43
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">exports.after = {</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      44
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  all: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      45
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  find: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      46
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  get: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-ins">
+      47
+    </td>
+    <td class="d2h-ins">
+        <div class="d2h-code-side-line d2h-ins">
+            <span class="d2h-code-line-prefix">+</span>
+            <span class="d2h-code-line-ctn">  create: <ins>[ populate({ schema: populateSchema }), serialize(serializeSchema) ],</ins></span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      48
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  update: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      49
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  patch: [],</span>
+        </div>
+    </td>
+</tr><tr>
+    <td class="d2h-code-side-linenumber d2h-cntx">
+      50
+    </td>
+    <td class="d2h-cntx">
+        <div class="d2h-code-side-line d2h-cntx">
+            <span class="d2h-code-line-prefix"> </span>
+            <span class="d2h-code-line-ctn">  remove: []</span>
+        </div>
+    </td>
+</tr>
+                    </tbody>
+                </table>
             </div>
-          </div>
         </div>
-      </div>
-      <div id="d2h-154219" class="d2h-file-wrapper" data-lang="930000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/process.js 1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/process.js
-              2017-01-03 11:12:35.930000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-files-diff">
-          <div class="d2h-file-side-diff">
+    </div>
+</div>
+<div id="d2h-154219" class="d2h-file-wrapper" data-lang="930000000 -0500">
+    <div class="d2h-file-header">
+      <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/process.js	1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/process.js	2017-01-03 11:12:35.930000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-files-diff">
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -1491,8 +1078,8 @@
                     </tbody>
                 </table>
             </div>
-          </div>
-          <div class="d2h-file-side-diff">
+        </div>
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -1653,24 +1240,20 @@
                     </tbody>
                 </table>
             </div>
-          </div>
         </div>
-      </div>
-      <div id="d2h-185000" class="d2h-file-wrapper" data-lang="918000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/src/services/message/hooks/restrict-to-sender.js 1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/restrict-to-sender.js
-              2017-01-01 16:00:47.918000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-files-diff">
-          <div class="d2h-file-side-diff">
+    </div>
+</div>
+<div id="d2h-185000" class="d2h-file-wrapper" data-lang="918000000 -0500">
+    <div class="d2h-file-header">
+      <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/src/services/message/hooks/restrict-to-sender.js	1969-12-31 19:00:00.000000000 -0500 → finish/src/services/message/hooks/restrict-to-sender.js	2017-01-01 16:00:47.918000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-files-diff">
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -1883,8 +1466,8 @@
                     </tbody>
                 </table>
             </div>
-          </div>
-          <div class="d2h-file-side-diff">
+        </div>
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -2144,24 +1727,20 @@
                     </tbody>
                 </table>
             </div>
-          </div>
         </div>
-      </div>
-      <div id="d2h-933848" class="d2h-file-wrapper" data-lang="086000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/test/services/message/hooks/process.test.js 1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/process.test.js
-              2017-01-01 13:38:18.086000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-files-diff">
-          <div class="d2h-file-side-diff">
+    </div>
+</div>
+<div id="d2h-933848" class="d2h-file-wrapper" data-lang="086000000 -0500">
+    <div class="d2h-file-header">
+      <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/test/services/message/hooks/process.test.js	1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/process.test.js	2017-01-01 13:38:18.086000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-files-diff">
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -2334,8 +1913,8 @@
                     </tbody>
                 </table>
             </div>
-          </div>
-          <div class="d2h-file-side-diff">
+        </div>
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -2544,24 +2123,20 @@
                     </tbody>
                 </table>
             </div>
-          </div>
         </div>
-      </div>
-      <div id="d2h-793450" class="d2h-file-wrapper" data-lang="014000000 -0500">
-        <div class="d2h-file-header">
-          <span class="d2h-file-name-wrapper">
-            <span class="d2h-icon-wrapper">
-              <svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
-                <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
-              </svg>
-            </span>
-            <span class="d2h-file-name">server/{client/test/services/message/hooks/restrict-to-sender.test.js 1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/restrict-to-sender.test.js
-              2017-01-01 15:56:40.014000000 -0500}</span>
-            <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span>
-          </span>
-        </div>
-        <div class="d2h-files-diff">
-          <div class="d2h-file-side-diff">
+    </div>
+</div>
+<div id="d2h-793450" class="d2h-file-wrapper" data-lang="014000000 -0500">
+    <div class="d2h-file-header">
+      <span class="d2h-file-name-wrapper">
+    <span class="d2h-icon-wrapper"><svg aria-hidden="true" class="d2h-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12">
+    <path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path>
+</svg></span>
+    <span class="d2h-file-name">server/{client/test/services/message/hooks/restrict-to-sender.test.js	1969-12-31 19:00:00.000000000 -0500 → finish/test/services/message/hooks/restrict-to-sender.test.js	2017-01-01 15:56:40.014000000 -0500}</span>
+    <span class="d2h-tag d2h-moved d2h-moved-tag">RENAMED</span></span>
+    </div>
+    <div class="d2h-files-diff">
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -2734,8 +2309,8 @@
                     </tbody>
                 </table>
             </div>
-          </div>
-          <div class="d2h-file-side-diff">
+        </div>
+        <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table">
                     <tbody class="d2h-diff-tbody">
@@ -2944,11 +2519,10 @@
                     </tbody>
                 </table>
             </div>
-          </div>
         </div>
-      </div>
     </div>
-  </div>
+</div>
+</div>
+</div>
 </body>
-
 </html>

--- a/examples/chat/_diff/server-finish.diff
+++ b/examples/chat/_diff/server-finish.diff
@@ -4,7 +4,7 @@ diff -bdur --new-file server/client/src/services/message/hooks/index.js server/f
 @@ -4,6 +4,28 @@
  const hooks = require('feathers-hooks');
  const auth = require('feathers-authentication').hooks;
- 
+
 +const restrictToSender = require('./restrict-to-sender');
 +const process = require('./process');
 +const { setCreatedAt, populate, dePopulate, serialize } = require('feathers-hooks-common');
@@ -43,7 +43,7 @@ diff -bdur --new-file server/client/src/services/message/hooks/index.js server/f
 +  patch: [ dePopulate(), restrictToSender() ],
 +  remove: [ restrictToSenderOrServer ]
  };
- 
+
  exports.after = {
    all: [],
 -  find: [],
@@ -66,13 +66,13 @@ diff -bdur --new-file server/client/src/services/message/hooks/process.js server
 +// Use this hook to manipulate incoming or outgoing data.
 +// For more information on hooks see: http://docs.feathersjs.com/hooks/readme.html
 +
-+module.exports = () => hook => {
-+  hook.data.text = hook.data.text
++module.exports = () => context => {
++  context.data.text = context.data.text
 +    .substring(0, 400) // Messages can't be longer than 400 characters
 +    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); // Do basic HTML escaping
-+  hook.data.userId = hook.params.user._id; // Add the authenticated user _id
-+  
-+  return hook;
++  context.data.userId = context.params.user._id; // Add the authenticated user _id
++
++  return context;
 +};
 diff -bdur --new-file server/client/src/services/message/hooks/restrict-to-sender.js server/finish/src/services/message/hooks/restrict-to-sender.js
 --- server/client/src/services/message/hooks/restrict-to-sender.js	1969-12-31 19:00:00.000000000 -0500
@@ -88,18 +88,18 @@ diff -bdur --new-file server/client/src/services/message/hooks/restrict-to-sende
 +const errors = require('feathers-errors');
 +
 +module.exports = function(options) {
-+  return function(hook) {
-+    const messageService = hook.app.service('messages');
-+    
++  return function(context) {
++    const messageService = context.app.service('messages');
++
 +    // First get the message that the user wants to access
-+    return messageService.get(hook.id, hook.params).then(message => {
++    return messageService.get(context.id, context.params).then(message => {
 +      // Throw a not authenticated error if the message and user id don't match
-+      if (message.sentBy._id !== hook.params.user._id && hook.provider) {
++      if (message.sentBy._id !== context.params.user._id && context.provider) {
 +        throw new errors.NotAuthenticated('Access not allowed');
 +      }
-+      
-+      // Otherwise just return the hook
-+      return hook;
++
++      // Otherwise just return the context
++      return context;
 +    });
 +  };
 +};
@@ -114,7 +114,7 @@ diff -bdur --new-file server/client/test/services/message/hooks/process.test.js 
 +
 +describe('message process hook', function() {
 +  it('hook can be used', function() {
-+    const mockHook = {
++    const mockContext = {
 +      type: 'before',
 +      app: {},
 +      params: {},
@@ -122,9 +122,9 @@ diff -bdur --new-file server/client/test/services/message/hooks/process.test.js 
 +      data: {}
 +    };
 +
-+    process()(mockHook);
++    process()(mockContext);
 +
-+    assert.ok(mockHook.process);
++    assert.ok(mockContext.process);
 +  });
 +});
 diff -bdur --new-file server/client/test/services/message/hooks/restrict-to-sender.test.js server/finish/test/services/message/hooks/restrict-to-sender.test.js
@@ -138,7 +138,7 @@ diff -bdur --new-file server/client/test/services/message/hooks/restrict-to-send
 +
 +describe('message restrictToSender hook', function() {
 +  it('hook can be used', function() {
-+    const mockHook = {
++    const mockContext = {
 +      type: 'before',
 +      app: {},
 +      params: {},
@@ -146,8 +146,8 @@ diff -bdur --new-file server/client/test/services/message/hooks/restrict-to-send
 +      data: {}
 +    };
 +
-+    restrictToSender()(mockHook);
++    restrictToSender()(mockContext);
 +
-+    assert.ok(mockHook.restrictToSender);
++    assert.ok(mockContext.restrictToSender);
 +  });
 +});

--- a/examples/chat/client/jquery/src/hooks/index.js
+++ b/examples/chat/client/jquery/src/hooks/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Add any common hooks you want to share across services in here.
-// 
+//
 // Below is an example of how a hook is written and exported. Please
 // see http://docs.feathersjs.com/hooks/readme.html for more details
 // on hooks.
 
 exports.myHook = function(options) {
-  return function(hook) {
+  return function(context) {
     console.log('My custom global hook ran. Feathers is awesome!');
   };
 };

--- a/examples/chat/client/jquery/src/services/message/hooks/process.js
+++ b/examples/chat/client/jquery/src/services/message/hooks/process.js
@@ -5,11 +5,11 @@
 // Use this hook to manipulate incoming or outgoing data.
 // For more information on hooks see: http://docs.feathersjs.com/hooks/readme.html
 
-module.exports = () => hook => {
-  hook.data.text = hook.data.text
+module.exports = () => context => {
+  context.data.text = context.data.text
     .substring(0, 400) // Messages can't be longer than 400 characters
     .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); // Do basic HTML escaping
-  hook.data.userId = hook.params.user._id; // Add the authenticated user _id
-  
-  return hook;
+  context.data.userId = context.params.user._id; // Add the authenticated user _id
+
+  return context;
 };

--- a/examples/chat/client/jquery/src/services/message/hooks/restrict-to-sender.js
+++ b/examples/chat/client/jquery/src/services/message/hooks/restrict-to-sender.js
@@ -8,18 +8,18 @@
 const errors = require('feathers-errors');
 
 module.exports = function(options) {
-  return function(hook) {
-    const messageService = hook.app.service('messages');
-    
+  return function(context) {
+    const messageService = context.app.service('messages');
+
     // First get the message that the user wants to access
-    return messageService.get(hook.id, hook.params).then(message => {
+    return messageService.get(context.id, context.params).then(message => {
       // Throw a not authenticated error if the message and user id don't match
-      if (message.sentBy._id !== hook.params.user._id && hook.provider) {
+      if (message.sentBy._id !== context.params.user._id && context.provider) {
         throw new errors.NotAuthenticated('Access not allowed');
       }
-      
-      // Otherwise just return the hook
-      return hook;
+
+      // Otherwise just return the context
+      return context;
     });
   };
 };

--- a/examples/chat/client/jquery/src/services/user/hooks/gravatar.js
+++ b/examples/chat/client/jquery/src/services/user/hooks/gravatar.js
@@ -17,15 +17,15 @@ const query = `s=60`;
 const gravatarImage = email => {
   // Gravatar uses MD5 hashes from an email address to get the image
   const hash = crypto.createHash('md5').update(email).digest('hex');
-  
+
   return `${gravatarUrl}/${hash}?${query}`;
 };
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // Assign the new data with the Gravatar image
-    hook.data = Object.assign({}, hook.data, {
-      avatar: gravatarImage(hook.data.email)
+    context.data = Object.assign({}, context.data, {
+      avatar: gravatarImage(context.data.email),
     });
   };
 };

--- a/examples/chat/client/jquery/test/services/message/hooks/process.test.js
+++ b/examples/chat/client/jquery/test/services/message/hooks/process.test.js
@@ -5,7 +5,7 @@ const process = require('../../../../src/services/message/hooks/process.js');
 
 describe('message process hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message process hook', function() {
       data: {}
     };
 
-    process()(mockHook);
+    process()(mockContext);
 
-    assert.ok(mockHook.process);
+    assert.ok(mockContext.process);
   });
 });

--- a/examples/chat/client/jquery/test/services/message/hooks/restrict-to-sender.test.js
+++ b/examples/chat/client/jquery/test/services/message/hooks/restrict-to-sender.test.js
@@ -5,7 +5,7 @@ const restrictToSender = require('../../../../src/services/message/hooks/restric
 
 describe('message restrictToSender hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message restrictToSender hook', function() {
       data: {}
     };
 
-    restrictToSender()(mockHook);
+    restrictToSender()(mockContext);
 
-    assert.ok(mockHook.restrictToSender);
+    assert.ok(mockContext.restrictToSender);
   });
 });

--- a/examples/chat/client/jquery/test/services/user/hooks/gravatar.test.js
+++ b/examples/chat/client/jquery/test/services/user/hooks/gravatar.test.js
@@ -5,7 +5,7 @@ const gravatar = require('../../../../src/services/user/hooks/gravatar.js');
 
 describe('user gravatar hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('user gravatar hook', function() {
       data: {}
     };
 
-    gravatar()(mockHook);
+    gravatar()(mockContext);
 
-    assert.ok(mockHook.gravatar);
+    assert.ok(mockContext.gravatar);
   });
 });

--- a/examples/chat/client/webpack/src/hooks/index.js
+++ b/examples/chat/client/webpack/src/hooks/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Add any common hooks you want to share across services in here.
-// 
+//
 // Below is an example of how a hook is written and exported. Please
 // see http://docs.feathersjs.com/hooks/readme.html for more details
 // on hooks.
 
 exports.myHook = function(options) {
-  return function(hook) {
+  return function(context) {
     console.log('My custom global hook ran. Feathers is awesome!');
   };
 };

--- a/examples/chat/client/webpack/src/services/message/hooks/process.js
+++ b/examples/chat/client/webpack/src/services/message/hooks/process.js
@@ -5,11 +5,11 @@
 // Use this hook to manipulate incoming or outgoing data.
 // For more information on hooks see: http://docs.feathersjs.com/hooks/readme.html
 
-module.exports = () => hook => {
-  hook.data.text = hook.data.text
+module.exports = () => context => {
+  context.data.text = context.data.text
     .substring(0, 400) // Messages can't be longer than 400 characters
     .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); // Do basic HTML escaping
-  hook.data.userId = hook.params.user._id; // Add the authenticated user _id
-  
-  return hook;
+  context.data.userId = context.params.user._id; // Add the authenticated user _id
+
+  return context;
 };

--- a/examples/chat/client/webpack/src/services/message/hooks/restrict-to-sender.js
+++ b/examples/chat/client/webpack/src/services/message/hooks/restrict-to-sender.js
@@ -8,18 +8,18 @@
 const errors = require('feathers-errors');
 
 module.exports = function(options) {
-  return function(hook) {
-    const messageService = hook.app.service('messages');
-    
+  return function(context) {
+    const messageService = context.app.service('messages');
+
     // First get the message that the user wants to access
-    return messageService.get(hook.id, hook.params).then(message => {
+    return messageService.get(context.id, context.params).then(message => {
       // Throw a not authenticated error if the message and user id don't match
-      if (message.sentBy._id !== hook.params.user._id && hook.provider) {
+      if (message.sentBy._id !== context.params.user._id && context.provider) {
         throw new errors.NotAuthenticated('Access not allowed');
       }
-      
-      // Otherwise just return the hook
-      return hook;
+
+      // Otherwise just return the context
+      return context;
     });
   };
 };

--- a/examples/chat/client/webpack/src/services/user/hooks/gravatar.js
+++ b/examples/chat/client/webpack/src/services/user/hooks/gravatar.js
@@ -17,15 +17,15 @@ const query = `s=60`;
 const gravatarImage = email => {
   // Gravatar uses MD5 hashes from an email address to get the image
   const hash = crypto.createHash('md5').update(email).digest('hex');
-  
+
   return `${gravatarUrl}/${hash}?${query}`;
 };
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // Assign the new data with the Gravatar image
-    hook.data = Object.assign({}, hook.data, {
-      avatar: gravatarImage(hook.data.email)
+    context.data = Object.assign({}, context.data, {
+      avatar: gravatarImage(context.data.email),
     });
   };
 };

--- a/examples/chat/client/webpack/test/services/message/hooks/process.test.js
+++ b/examples/chat/client/webpack/test/services/message/hooks/process.test.js
@@ -5,7 +5,7 @@ const process = require('../../../../src/services/message/hooks/process.js');
 
 describe('message process hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message process hook', function() {
       data: {}
     };
 
-    process()(mockHook);
+    process()(mockContext);
 
-    assert.ok(mockHook.process);
+    assert.ok(mockContext.process);
   });
 });

--- a/examples/chat/client/webpack/test/services/message/hooks/restrict-to-sender.test.js
+++ b/examples/chat/client/webpack/test/services/message/hooks/restrict-to-sender.test.js
@@ -5,7 +5,7 @@ const restrictToSender = require('../../../../src/services/message/hooks/restric
 
 describe('message restrictToSender hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message restrictToSender hook', function() {
       data: {}
     };
 
-    restrictToSender()(mockHook);
+    restrictToSender()(mockContext);
 
-    assert.ok(mockHook.restrictToSender);
+    assert.ok(mockContext.restrictToSender);
   });
 });

--- a/examples/chat/client/webpack/test/services/user/hooks/gravatar.test.js
+++ b/examples/chat/client/webpack/test/services/user/hooks/gravatar.test.js
@@ -5,7 +5,7 @@ const gravatar = require('../../../../src/services/user/hooks/gravatar.js');
 
 describe('user gravatar hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('user gravatar hook', function() {
       data: {}
     };
 
-    gravatar()(mockHook);
+    gravatar()(mockContext);
 
-    assert.ok(mockHook.gravatar);
+    assert.ok(mockContext.gravatar);
   });
 });

--- a/examples/chat/server/client/src/hooks/index.js
+++ b/examples/chat/server/client/src/hooks/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Add any common hooks you want to share across services in here.
-// 
+//
 // Below is an example of how a hook is written and exported. Please
 // see http://docs.feathersjs.com/hooks/readme.html for more details
 // on hooks.
 
-exports.myHook = function(options) {
-  return function(hook) {
+exports.myHook = function (options) {
+  return function (context) {
     console.log('My custom global hook ran. Feathers is awesome!');
   };
 };

--- a/examples/chat/server/client/src/services/user/hooks/gravatar.js
+++ b/examples/chat/server/client/src/services/user/hooks/gravatar.js
@@ -17,15 +17,15 @@ const query = `s=60`;
 const gravatarImage = email => {
   // Gravatar uses MD5 hashes from an email address to get the image
   const hash = crypto.createHash('md5').update(email).digest('hex');
-  
+
   return `${gravatarUrl}/${hash}?${query}`;
 };
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // Assign the new data with the Gravatar image
-    hook.data = Object.assign({}, hook.data, {
-      avatar: gravatarImage(hook.data.email)
+    context.data = Object.assign({}, context.data, {
+      avatar: gravatarImage(context.data.email)
     });
   };
 };

--- a/examples/chat/server/client/test/services/user/hooks/gravatar.test.js
+++ b/examples/chat/server/client/test/services/user/hooks/gravatar.test.js
@@ -5,7 +5,7 @@ const gravatar = require('../../../../src/services/user/hooks/gravatar.js');
 
 describe('user gravatar hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('user gravatar hook', function() {
       data: {}
     };
 
-    gravatar()(mockHook);
+    gravatar()(mockContext);
 
-    assert.ok(mockHook.gravatar);
+    assert.ok(mockContext.gravatar);
   });
 });

--- a/examples/chat/server/finish/src/hooks/index.js
+++ b/examples/chat/server/finish/src/hooks/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Add any common hooks you want to share across services in here.
-// 
+//
 // Below is an example of how a hook is written and exported. Please
 // see http://docs.feathersjs.com/hooks/readme.html for more details
 // on hooks.
 
 exports.myHook = function(options) {
-  return function(hook) {
+  return function(context) {
     console.log('My custom global hook ran. Feathers is awesome!');
   };
 };

--- a/examples/chat/server/finish/src/services/message/hooks/process.js
+++ b/examples/chat/server/finish/src/services/message/hooks/process.js
@@ -5,11 +5,11 @@
 // Use this hook to manipulate incoming or outgoing data.
 // For more information on hooks see: http://docs.feathersjs.com/hooks/readme.html
 
-module.exports = () => hook => {
-  hook.data.text = hook.data.text
+module.exports = () => context => {
+  context.data.text = context.data.text
     .substring(0, 400) // Messages can't be longer than 400 characters
     .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); // Do basic HTML escaping
-  hook.data.userId = hook.params.user._id; // Add the authenticated user _id
-  
-  return hook;
+  context.data.userId = context.params.user._id; // Add the authenticated user _id
+
+  return context;
 };

--- a/examples/chat/server/finish/src/services/message/hooks/restrict-to-sender.js
+++ b/examples/chat/server/finish/src/services/message/hooks/restrict-to-sender.js
@@ -8,18 +8,18 @@
 const errors = require('feathers-errors');
 
 module.exports = function(options) {
-  return function(hook) {
-    const messageService = hook.app.service('messages');
-    
+  return function(context) {
+    const messageService = context.app.service('messages');
+
     // First get the message that the user wants to access
-    return messageService.get(hook.id, hook.params).then(message => {
+    return messageService.get(context.id, context.params).then(message => {
       // Throw a not authenticated error if the message and user id don't match
-      if (message.sentBy._id !== hook.params.user._id && hook.provider) {
+      if (message.sentBy._id !== context.params.user._id && context.provider) {
         throw new errors.NotAuthenticated('Access not allowed');
       }
-      
-      // Otherwise just return the hook
-      return hook;
+
+      // Otherwise just return the context
+      return context;
     });
   };
 };

--- a/examples/chat/server/finish/src/services/user/hooks/gravatar.js
+++ b/examples/chat/server/finish/src/services/user/hooks/gravatar.js
@@ -17,15 +17,15 @@ const query = `s=60`;
 const gravatarImage = email => {
   // Gravatar uses MD5 hashes from an email address to get the image
   const hash = crypto.createHash('md5').update(email).digest('hex');
-  
+
   return `${gravatarUrl}/${hash}?${query}`;
 };
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // Assign the new data with the Gravatar image
-    hook.data = Object.assign({}, hook.data, {
-      avatar: gravatarImage(hook.data.email)
+    context.data = Object.assign({}, context.data, {
+      avatar: gravatarImage(context.data.email)
     });
   };
 };

--- a/examples/chat/server/finish/test/services/message/hooks/process.test.js
+++ b/examples/chat/server/finish/test/services/message/hooks/process.test.js
@@ -5,7 +5,7 @@ const process = require('../../../../src/services/message/hooks/process.js');
 
 describe('message process hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message process hook', function() {
       data: {}
     };
 
-    process()(mockHook);
+    process()(mockContext);
 
-    assert.ok(mockHook.process);
+    assert.ok(mockContext.process);
   });
 });

--- a/examples/chat/server/finish/test/services/message/hooks/restrict-to-sender.test.js
+++ b/examples/chat/server/finish/test/services/message/hooks/restrict-to-sender.test.js
@@ -5,7 +5,7 @@ const restrictToSender = require('../../../../src/services/message/hooks/restric
 
 describe('message restrictToSender hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('message restrictToSender hook', function() {
       data: {}
     };
 
-    restrictToSender()(mockHook);
+    restrictToSender()(mockContext);
 
-    assert.ok(mockHook.restrictToSender);
+    assert.ok(mockContext.restrictToSender);
   });
 });

--- a/examples/chat/server/finish/test/services/user/hooks/gravatar.test.js
+++ b/examples/chat/server/finish/test/services/user/hooks/gravatar.test.js
@@ -5,7 +5,7 @@ const gravatar = require('../../../../src/services/user/hooks/gravatar.js');
 
 describe('user gravatar hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('user gravatar hook', function() {
       data: {}
     };
 
-    gravatar()(mockHook);
+    gravatar()(mockContext);
 
-    assert.ok(mockHook.gravatar);
+    assert.ok(mockContext.gravatar);
   });
 });

--- a/examples/chat/server/start/src/hooks/index.js
+++ b/examples/chat/server/start/src/hooks/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Add any common hooks you want to share across services in here.
-// 
+//
 // Below is an example of how a hook is written and exported. Please
 // see http://docs.feathersjs.com/hooks/readme.html for more details
 // on hooks.
 
 exports.myHook = function(options) {
-  return function(hook) {
+  return function(context) {
     console.log('My custom global hook ran. Feathers is awesome!');
   };
 };

--- a/examples/chat/server/start/src/services/user/hooks/gravatar.js
+++ b/examples/chat/server/start/src/services/user/hooks/gravatar.js
@@ -17,15 +17,15 @@ const query = `s=60`;
 const gravatarImage = email => {
   // Gravatar uses MD5 hashes from an email address to get the image
   const hash = crypto.createHash('md5').update(email).digest('hex');
-  
+
   return `${gravatarUrl}/${hash}?${query}`;
 };
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // Assign the new data with the Gravatar image
-    hook.data = Object.assign({}, hook.data, {
-      avatar: gravatarImage(hook.data.email)
+    context.data = Object.assign({}, context.data, {
+      avatar: gravatarImage(context.data.email)
     });
   };
 };

--- a/examples/chat/server/start/test/services/user/hooks/gravatar.test.js
+++ b/examples/chat/server/start/test/services/user/hooks/gravatar.test.js
@@ -5,7 +5,7 @@ const gravatar = require('../../../../src/services/user/hooks/gravatar.js');
 
 describe('user gravatar hook', function() {
   it('hook can be used', function() {
-    const mockHook = {
+    const mockContext = {
       type: 'before',
       app: {},
       params: {},
@@ -13,8 +13,8 @@ describe('user gravatar hook', function() {
       data: {}
     };
 
-    gravatar()(mockHook);
+    gravatar()(mockContext);
 
-    assert.ok(mockHook.gravatar);
+    assert.ok(mockContext.gravatar);
   });
 });

--- a/examples/offline/common/src1/hooks/logger.js
+++ b/examples/offline/common/src1/hooks/logger.js
@@ -4,23 +4,23 @@
 const logger = require('../../../node_modules/winston');
 
 module.exports = function () {
-  return function (hook) {
-    let message = `${hook.type}: ${hook.path} - Method: ${hook.method}`;
+  return function (context) {
+    let message = `${context.type}: ${context.path} - Method: ${context.method}`;
 
-    if (hook.type === 'error') {
-      message += `: ${hook.error.message}`;
+    if (context.type === 'error') {
+      message += `: ${context.error.message}`;
     }
 
     logger.info(message);
-    logger.debug('hook.data', hook.data);
-    logger.debug('hook.params', hook.params);
+    logger.debug('context.data', context.data);
+    logger.debug('context.params', context.params);
 
-    if (hook.result) {
-      logger.debug('hook.result', hook.result);
+    if (context.result) {
+      logger.debug('context.result', context.result);
     }
 
-    if (hook.error) {
-      logger.error(hook.error);
+    if (context.error) {
+      logger.error(context.error);
     }
   };
 };

--- a/examples/offline/common/src1/services/stock/stock.filters.js
+++ b/examples/offline/common/src1/services/stock/stock.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 // console.warn('You are using the default filter for the stock service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/01/hooks/1.js
+++ b/examples/step/01/hooks/1.js
@@ -46,7 +46,7 @@ function user() {
       setUpdatedAt()
     ]});
   userService.after({
-    all: unless(hook => hook.method === 'find', remove('password')),
+    all: unless(context => context.method === 'find', remove('password')),
   });
 }
 

--- a/examples/step/01/hooks/2.js
+++ b/examples/step/01/hooks/2.js
@@ -40,7 +40,7 @@ function user() {
   } = commonHooks;
 
   userService.before({
-    all: when(hook => hook.method !== 'find', softDelete()),
+    all: when(context => context.method !== 'find', softDelete()),
     create: [
       validateSchema(userSchema(), Ajv),
       authHooks.hashPassword(),
@@ -48,7 +48,7 @@ function user() {
       setUpdatedAt()
     ]});
   userService.after({
-    all: unless(hook => hook.method === 'find', remove('password')),
+    all: unless(context => context.method === 'find', remove('password')),
   });
 }
 

--- a/examples/step/02/gen1/src/hooks/logger.js
+++ b/examples/step/02/gen1/src/hooks/logger.js
@@ -4,23 +4,23 @@
 const logger = require('winston');
 
 module.exports = function () {
-  return function (hook) {
-    let message = `${hook.type}: ${hook.path} - Method: ${hook.method}`;
+  return function (context) {
+    let message = `${context.type}: ${context.path} - Method: ${context.method}`;
 
-    if (hook.type === 'error') {
-      message += `: ${hook.error.message}`;
+    if (context.type === 'error') {
+      message += `: ${context.error.message}`;
     }
 
     logger.info(message);
-    logger.debug('hook.data', hook.data);
-    logger.debug('hook.params', hook.params);
+    logger.debug('context.data', context.data);
+    logger.debug('context.params', context.params);
 
-    if (hook.result) {
-      logger.debug('hook.result', hook.result);
+    if (context.result) {
+      logger.debug('context.result', context.result);
     }
 
-    if (hook.error) {
-      logger.error(hook.error);
+    if (context.error) {
+      logger.error(context.error);
     }
   };
 };

--- a/examples/step/02/gen2/src/hooks/logger.js
+++ b/examples/step/02/gen2/src/hooks/logger.js
@@ -4,23 +4,23 @@
 const logger = require('winston');
 
 module.exports = function () {
-  return function (hook) {
-    let message = `${hook.type}: ${hook.path} - Method: ${hook.method}`;
+  return function (context) {
+    let message = `${context.type}: ${context.path} - Method: ${context.method}`;
 
-    if (hook.type === 'error') {
-      message += `: ${hook.error.message}`;
+    if (context.type === 'error') {
+      message += `: ${context.error.message}`;
     }
 
     logger.info(message);
-    logger.debug('hook.data', hook.data);
-    logger.debug('hook.params', hook.params);
+    logger.debug('context.data', context.data);
+    logger.debug('context.params', context.params);
 
-    if (hook.result) {
-      logger.debug('hook.result', hook.result);
+    if (context.result) {
+      logger.debug('context.result', context.result);
     }
 
-    if (hook.error) {
-      logger.error(hook.error);
+    if (context.error) {
+      logger.error(context.error);
     }
   };
 };

--- a/examples/step/02/gen2/src/services/users/users.filters.js
+++ b/examples/step/02/gen2/src/services/users/users.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 console.warn('You are using the default filter for the users service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/02/gen2/src/services/users/users.hooks.js
+++ b/examples/step/02/gen2/src/services/users/users.hooks.js
@@ -27,7 +27,7 @@ module.exports = {
   after: {
     all: [
       commonHooks.when(
-        hook => hook.params.provider,
+        context => context.params.provider,
         commonHooks.discard('password')
       )
     ],

--- a/examples/step/02/gen3/src/hooks/logger.js
+++ b/examples/step/02/gen3/src/hooks/logger.js
@@ -4,23 +4,23 @@
 const logger = require('winston');
 
 module.exports = function () {
-  return function (hook) {
-    let message = `${hook.type}: ${hook.path} - Method: ${hook.method}`;
+  return function (context) {
+    let message = `${context.type}: ${context.path} - Method: ${context.method}`;
 
-    if (hook.type === 'error') {
-      message += `: ${hook.error.message}`;
+    if (context.type === 'error') {
+      message += `: ${context.error.message}`;
     }
 
     logger.info(message);
-    logger.debug('hook.data', hook.data);
-    logger.debug('hook.params', hook.params);
+    logger.debug('context.data', context.data);
+    logger.debug('context.params', context.params);
 
-    if (hook.result) {
-      logger.debug('hook.result', hook.result);
+    if (context.result) {
+      logger.debug('context.result', context.result);
     }
 
-    if (hook.error) {
-      logger.error(hook.error);
+    if (context.error) {
+      logger.error(context.error);
     }
   };
 };

--- a/examples/step/02/gen3/src/services/teams/teams.filters.js
+++ b/examples/step/02/gen3/src/services/teams/teams.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 console.warn('You are using the default filter for the teams service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/02/gen3/src/services/users/users.filters.js
+++ b/examples/step/02/gen3/src/services/users/users.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 console.warn('You are using the default filter for the users service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/02/gen3/src/services/users/users.hooks.js
+++ b/examples/step/02/gen3/src/services/users/users.hooks.js
@@ -27,7 +27,7 @@ module.exports = {
   after: {
     all: [
       commonHooks.when(
-        hook => hook.params.provider,
+        context => context.params.provider,
         commonHooks.discard('password')
       )
     ],

--- a/examples/step/02/gen4/src/hooks/logger.js
+++ b/examples/step/02/gen4/src/hooks/logger.js
@@ -4,23 +4,23 @@
 const logger = require('winston');
 
 module.exports = function () {
-  return function (hook) {
-    let message = `${hook.type}: ${hook.path} - Method: ${hook.method}`;
+  return function (context) {
+    let message = `${context.type}: ${context.path} - Method: ${context.method}`;
 
-    if (hook.type === 'error') {
-      message += `: ${hook.error.message}`;
+    if (context.type === 'error') {
+      message += `: ${context.error.message}`;
     }
 
     logger.info(message);
-    logger.debug('hook.data', hook.data);
-    logger.debug('hook.params', hook.params);
+    logger.debug('context.data', context.data);
+    logger.debug('context.params', context.params);
 
-    if (hook.result) {
-      logger.debug('hook.result', hook.result);
+    if (context.result) {
+      logger.debug('context.result', context.result);
     }
 
-    if (hook.error) {
-      logger.error(hook.error);
+    if (context.error) {
+      logger.error(context.error);
     }
   };
 };

--- a/examples/step/02/gen4/src/hooks/populate-teams.js
+++ b/examples/step/02/gen4/src/hooks/populate-teams.js
@@ -4,9 +4,9 @@
 // For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
 
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
-  return function (hook) {
+  return function (context) {
     // Hooks can either return nothing or a promise
-    // that resolves with the `hook` object for asynchronous operations
-    return Promise.resolve(hook);
+    // that resolves with the `context` object for asynchronous operations
+    return Promise.resolve(context);
   };
 };

--- a/examples/step/02/gen4/src/services/teams/teams.filters.js
+++ b/examples/step/02/gen4/src/services/teams/teams.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 console.warn('You are using the default filter for the teams service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/02/gen4/src/services/users/users.filters.js
+++ b/examples/step/02/gen4/src/services/users/users.filters.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 1 */
 console.warn('You are using the default filter for the users service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 
-module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
+module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
   return data;
 };

--- a/examples/step/02/gen4/src/services/users/users.hooks.js
+++ b/examples/step/02/gen4/src/services/users/users.hooks.js
@@ -27,7 +27,7 @@ module.exports = {
   after: {
     all: [
       commonHooks.when(
-        hook => hook.params.provider,
+        context => context.params.provider,
         commonHooks.discard('password')
       )
     ],

--- a/examples/step/02/gen4/test/hooks/populate-teams.test.js
+++ b/examples/step/02/gen4/test/hooks/populate-teams.test.js
@@ -5,15 +5,15 @@ const populateTeams = require('../../src/hooks/populate-teams');
 
 describe('\'populateTeams\' hook', () => {
   it('runs the hook', () => {
-    // A mock hook object
+    // A mock context object
     const mock = {};
     // Initialize our hook with no options
     const hook = populateTeams();
 
     // Run the hook function (which returns a promise)
-    // and compare the resulting hook object
+    // and compare the resulting context object
     return hook(mock).then(result => {
-      assert.equal(result, mock, 'Returns the expected hook object');
+      assert.equal(result, mock, 'Returns the expected context object');
     });
   });
 });

--- a/examples/step/_diff/01-hooks-1-line.html
+++ b/examples/step/_diff/01-hooks-1-line.html
@@ -553,7 +553,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    all: unless(hook =&gt; hook.method === 'find', remove('password')),</span>
+            <span class="d2h-code-line-ctn">    all: unless(context =&gt; context.method === 'find', remove('password')),</span>
         </div>
     </td>
 </tr><tr>
@@ -820,7 +820,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return hook =&gt; hook;</span>
+            <span class="d2h-code-line-ctn">  return context =&gt; context;</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/01-hooks-1-side.html
+++ b/examples/step/_diff/01-hooks-1-side.html
@@ -140,7 +140,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -148,7 +148,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -156,7 +156,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -164,7 +164,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -172,7 +172,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -190,7 +190,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -272,7 +272,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -280,7 +280,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -288,7 +288,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -296,7 +296,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -304,7 +304,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -312,7 +312,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -320,7 +320,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -328,7 +328,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -336,7 +336,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -344,7 +344,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -352,7 +352,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -360,7 +360,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -368,7 +368,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -376,7 +376,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -384,7 +384,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -392,7 +392,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -400,7 +400,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -408,7 +408,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -416,7 +416,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -424,7 +424,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -432,7 +432,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -440,7 +440,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -512,7 +512,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -520,7 +520,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -528,7 +528,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -536,7 +536,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -544,7 +544,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -552,7 +552,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -560,7 +560,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -568,7 +568,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -576,7 +576,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -584,7 +584,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -592,7 +592,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -600,7 +600,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -608,7 +608,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -616,7 +616,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -624,7 +624,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -632,7 +632,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -640,7 +640,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -648,7 +648,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1099,7 +1099,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    all: unless(hook =&gt; hook.method === 'find', remove('password')),</span>
+            <span class="d2h-code-line-ctn">    all: unless(context =&gt; context.method === 'find', remove('password')),</span>
         </div>
     </td>
 </tr><tr>
@@ -1341,7 +1341,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return hook =&gt; hook;</span>
+            <span class="d2h-code-line-ctn">  return context =&gt; context;</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/01-hooks-1.diff
+++ b/examples/step/_diff/01-hooks-1.diff
@@ -1,16 +1,16 @@
 --- 01/websocket/1.js	2017-03-29 08:57:36.697999415 -0400
 +++ 01/hooks/1.js	2017-03-29 08:57:36.697999415 -0400
 @@ -1,5 +1,5 @@
- 
+
 -// Example - Create REST & socketio API, and serve static files
 +// Example - Use hooks with service
- 
+
  const expressServerConfig = require('../common/expressServerConfig');
  const expressMiddleware = require('../common/expressMiddleware');
 @@ -9,7 +9,13 @@
  const path = require('path');
  const service = require('feathers-nedb');
- 
+
 +const Ajv = require('ajv');
 +const authHooks = require('feathers-authentication-local').hooks;
 +const hooks = require('feathers-hooks');
@@ -23,7 +23,7 @@
    .configure(services)
 @@ -19,7 +25,29 @@
  server.on('listening', () => console.log(`Feathers application started on port 3030`));
- 
+
  function services() {
 -  this.use('/users', service({ Model: userModel() }));
 +  this.configure(user);
@@ -31,14 +31,14 @@
 +
 +function user() {
 +  const app = this;
-+  
++
 +  app.use('/users', service({ Model: userModel() }));
 +  const userService = app.service('users');
-+  
++
 +  const {
 +    setCreatedAt, setUpdatedAt, unless, remove /* , validateSchema */
 +  } = commonHooks;
-+  
++
 +  userService.before({
 +    create: [
 +      validateSchema(userSchema(), Ajv),
@@ -47,10 +47,10 @@
 +      setUpdatedAt()
 +    ]});
 +  userService.after({
-+    all: unless(hook => hook.method === 'find', remove('password')),
++    all: unless(context => context.method === 'find', remove('password')),
 +  });
  }
- 
+
  function userModel() {
 @@ -28,3 +56,21 @@
      autoload: true
@@ -72,5 +72,5 @@
 +}
 +
 +function validateSchema() { // todo replace
-+  return hook => hook;
++  return context => context;
 +}

--- a/examples/step/_diff/01-hooks-2-line.html
+++ b/examples/step/_diff/01-hooks-2-line.html
@@ -221,7 +221,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    all: when(hook =&gt; hook.method !== 'find', softDelete()),</span>
+            <span class="d2h-code-line-ctn">    all: when(context =&gt; context.method !== 'find', softDelete()),</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/01-hooks-2-side.html
+++ b/examples/step/_diff/01-hooks-2-side.html
@@ -141,7 +141,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -189,7 +189,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -379,7 +379,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    all: when(hook =&gt; hook.method !== 'find', softDelete()),</span>
+            <span class="d2h-code-line-ctn">    all: when(context =&gt; context.method !== 'find', softDelete()),</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/01-hooks-2.diff
+++ b/examples/step/_diff/01-hooks-2.diff
@@ -1,22 +1,22 @@
 --- 01/hooks/1.js	2017-03-29 08:57:36.697999415 -0400
 +++ 01/hooks/2.js	2017-03-29 08:57:36.697999415 -0400
 @@ -1,5 +1,5 @@
- 
+
 -// Example - Use hooks with service
 +// Example - Use soft deletes with a service
- 
+
  const expressServerConfig = require('../common/expressServerConfig');
  const expressMiddleware = require('../common/expressMiddleware');
 @@ -35,10 +35,12 @@
    const userService = app.service('users');
-   
+
    const {
 +    softDelete, when,
      setCreatedAt, setUpdatedAt, unless, remove /* , validateSchema */
    } = commonHooks;
-   
+
    userService.before({
-+    all: when(hook => hook.method !== 'find', softDelete()),
++    all: when(context => context.method !== 'find', softDelete()),
      create: [
        validateSchema(userSchema(), Ajv),
        authHooks.hashPassword(),

--- a/examples/step/_diff/02-gen2-line.html
+++ b/examples/step/_diff/02-gen2-line.html
@@ -1528,7 +1528,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars</span>
+            <span class="d2h-code-line-ctn">module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars</span>
         </div>
     </td>
 </tr><tr>
@@ -1900,7 +1900,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">        hook =&gt; hook.params.provider,</span>
+            <span class="d2h-code-line-ctn">        context =&gt; context.params.provider,</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/02-gen2-side.html
+++ b/examples/step/_diff/02-gen2-side.html
@@ -88,7 +88,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -96,7 +96,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -104,7 +104,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -112,7 +112,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -120,7 +120,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -128,7 +128,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -136,7 +136,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -144,7 +144,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -152,7 +152,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -160,7 +160,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -168,7 +168,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -176,7 +176,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -184,7 +184,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -192,7 +192,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -200,7 +200,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -208,7 +208,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -216,7 +216,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -224,7 +224,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -232,7 +232,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -240,7 +240,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -248,7 +248,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -256,7 +256,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -264,7 +264,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -272,7 +272,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -290,7 +290,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -298,7 +298,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -696,7 +696,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -704,7 +704,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -712,7 +712,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -720,7 +720,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -768,7 +768,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -806,7 +806,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1103,7 +1103,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1111,7 +1111,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1182,7 +1182,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1190,7 +1190,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1428,7 +1428,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1436,7 +1436,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1444,7 +1444,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1452,7 +1452,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1460,7 +1460,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1468,7 +1468,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1476,7 +1476,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1484,7 +1484,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1492,7 +1492,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1500,7 +1500,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1508,7 +1508,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1516,7 +1516,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1524,7 +1524,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1532,7 +1532,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1540,7 +1540,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1548,7 +1548,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1556,7 +1556,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1564,7 +1564,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1572,7 +1572,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1580,7 +1580,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1588,7 +1588,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1596,7 +1596,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1604,7 +1604,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1612,7 +1612,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1620,7 +1620,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1628,7 +1628,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1636,7 +1636,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1644,7 +1644,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1652,7 +1652,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1660,7 +1660,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2003,7 +2003,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2011,7 +2011,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2019,7 +2019,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2027,7 +2027,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2035,7 +2035,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2043,7 +2043,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2051,7 +2051,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2059,7 +2059,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2067,7 +2067,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2075,7 +2075,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2083,7 +2083,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2091,7 +2091,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2099,7 +2099,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2107,7 +2107,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2311,7 +2311,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2319,7 +2319,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2347,7 +2347,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2483,7 +2483,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2491,7 +2491,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2499,7 +2499,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2507,7 +2507,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2515,7 +2515,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2523,7 +2523,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2579,7 +2579,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars</span>
+            <span class="d2h-code-line-ctn">module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars</span>
         </div>
     </td>
 </tr><tr>
@@ -2630,7 +2630,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2638,7 +2638,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2646,7 +2646,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2654,7 +2654,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2662,7 +2662,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2670,7 +2670,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2678,7 +2678,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2686,7 +2686,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2694,7 +2694,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2702,7 +2702,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2710,7 +2710,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2718,7 +2718,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2726,7 +2726,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2734,7 +2734,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2742,7 +2742,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2750,7 +2750,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2758,7 +2758,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2766,7 +2766,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2774,7 +2774,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2782,7 +2782,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2790,7 +2790,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2798,7 +2798,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2806,7 +2806,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2814,7 +2814,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2822,7 +2822,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2830,7 +2830,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2838,7 +2838,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2846,7 +2846,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2854,7 +2854,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2862,7 +2862,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2870,7 +2870,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2878,7 +2878,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2886,7 +2886,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2894,7 +2894,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2902,7 +2902,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2910,7 +2910,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2918,7 +2918,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2926,7 +2926,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2934,7 +2934,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2942,7 +2942,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2950,7 +2950,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2958,7 +2958,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2966,7 +2966,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2974,7 +2974,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2982,7 +2982,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2990,7 +2990,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2998,7 +2998,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3006,7 +3006,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3014,7 +3014,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3022,7 +3022,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3030,7 +3030,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3343,7 +3343,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">        hook =&gt; hook.params.provider,</span>
+            <span class="d2h-code-line-ctn">        context =&gt; context.params.provider,</span>
         </div>
     </td>
 </tr><tr>
@@ -3583,7 +3583,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3591,7 +3591,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3599,7 +3599,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3607,7 +3607,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3615,7 +3615,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3623,7 +3623,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3631,7 +3631,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3639,7 +3639,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3647,7 +3647,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3655,7 +3655,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3663,7 +3663,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3671,7 +3671,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3679,7 +3679,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3687,7 +3687,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3695,7 +3695,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3703,7 +3703,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3711,7 +3711,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3719,7 +3719,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3727,7 +3727,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3735,7 +3735,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3743,7 +3743,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3751,7 +3751,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3759,7 +3759,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3767,7 +3767,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3775,7 +3775,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3783,7 +3783,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3791,7 +3791,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3799,7 +3799,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3807,7 +3807,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3815,7 +3815,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -3823,7 +3823,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4174,7 +4174,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4182,7 +4182,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4190,7 +4190,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4198,7 +4198,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4206,7 +4206,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4214,7 +4214,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4222,7 +4222,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4230,7 +4230,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4238,7 +4238,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4246,7 +4246,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4254,7 +4254,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -4262,7 +4262,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">

--- a/examples/step/_diff/02-gen2.diff
+++ b/examples/step/_diff/02-gen2.diff
@@ -62,16 +62,16 @@ diff -bdur --new-file 02/gen1/src/app.js 02/gen2/src/app.js
 @@ -17,6 +17,8 @@
  const services = require('./services');
  const appHooks = require('./app.hooks');
- 
+
 +const authentication = require('./authentication');
 +
  const app = feathers();
- 
+
  // Load app configuration
 @@ -36,6 +38,8 @@
  app.configure(rest());
  app.configure(socketio());
- 
+
 +app.configure(authentication);
 +
  // Set up our services (see `services/index.js`)
@@ -134,7 +134,7 @@ diff -bdur --new-file 02/gen1/src/services/index.js 02/gen2/src/services/index.j
 +++ 02/gen2/src/services/index.js	2017-04-09 09:12:41.798007000 -0400
 @@ -1,5 +1,8 @@
  'use strict';
- 
+
 +const users = require('./users/users.service.js');
 +
  module.exports = function () {
@@ -148,7 +148,7 @@ diff -bdur --new-file 02/gen1/src/services/users/users.filters.js 02/gen2/src/se
 +/* eslint no-console: 1 */
 +console.warn('You are using the default filter for the users service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 +
-+module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
++module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
 +  return data;
 +};
 diff -bdur --new-file 02/gen1/src/services/users/users.hooks.js 02/gen2/src/services/users/users.hooks.js
@@ -184,7 +184,7 @@ diff -bdur --new-file 02/gen1/src/services/users/users.hooks.js 02/gen2/src/serv
 +  after: {
 +    all: [
 +      commonHooks.when(
-+        hook => hook.params.provider,
++        context => context.params.provider,
 +        commonHooks.discard('password')
 +      )
 +    ],

--- a/examples/step/_diff/02-gen3-line.html
+++ b/examples/step/_diff/02-gen3-line.html
@@ -380,7 +380,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars</span>
+            <span class="d2h-code-line-ctn">module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/02-gen3-side.html
+++ b/examples/step/_diff/02-gen3-side.html
@@ -58,7 +58,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -66,7 +66,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -74,7 +74,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -82,7 +82,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -90,7 +90,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -98,7 +98,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -106,7 +106,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -114,7 +114,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -122,7 +122,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -130,7 +130,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -138,7 +138,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -146,7 +146,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -340,7 +340,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -348,7 +348,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -386,7 +386,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -541,7 +541,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -549,7 +549,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -557,7 +557,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -565,7 +565,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -573,7 +573,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -581,7 +581,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -637,7 +637,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars</span>
+            <span class="d2h-code-line-ctn">module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars</span>
         </div>
     </td>
 </tr><tr>
@@ -688,7 +688,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -696,7 +696,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -704,7 +704,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -712,7 +712,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -720,7 +720,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -728,7 +728,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -736,7 +736,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -744,7 +744,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -752,7 +752,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -760,7 +760,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -768,7 +768,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -776,7 +776,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -784,7 +784,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -792,7 +792,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -800,7 +800,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -808,7 +808,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -816,7 +816,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -824,7 +824,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -832,7 +832,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -840,7 +840,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -848,7 +848,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -856,7 +856,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -864,7 +864,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -872,7 +872,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -880,7 +880,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -888,7 +888,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -896,7 +896,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -904,7 +904,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -912,7 +912,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -920,7 +920,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -928,7 +928,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -936,7 +936,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -944,7 +944,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -952,7 +952,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -960,7 +960,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1354,7 +1354,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1362,7 +1362,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1370,7 +1370,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1378,7 +1378,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1386,7 +1386,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1394,7 +1394,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1402,7 +1402,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1410,7 +1410,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1418,7 +1418,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1426,7 +1426,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1434,7 +1434,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1442,7 +1442,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1450,7 +1450,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1458,7 +1458,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1466,7 +1466,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1474,7 +1474,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1482,7 +1482,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1490,7 +1490,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1498,7 +1498,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1506,7 +1506,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1514,7 +1514,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1522,7 +1522,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1530,7 +1530,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1538,7 +1538,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1546,7 +1546,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1554,7 +1554,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1562,7 +1562,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1570,7 +1570,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1578,7 +1578,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1586,7 +1586,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1594,7 +1594,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1945,7 +1945,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1953,7 +1953,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1961,7 +1961,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1969,7 +1969,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1977,7 +1977,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1985,7 +1985,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -1993,7 +1993,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2001,7 +2001,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2009,7 +2009,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2017,7 +2017,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2025,7 +2025,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -2033,7 +2033,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">

--- a/examples/step/_diff/02-gen3.diff
+++ b/examples/step/_diff/02-gen3.diff
@@ -18,9 +18,9 @@ diff -bdur --new-file 02/gen2/src/services/index.js 02/gen3/src/services/index.j
 --- 02/gen2/src/services/index.js	2017-04-09 09:12:41.798007000 -0400
 +++ 02/gen3/src/services/index.js	2017-04-09 09:15:24.634007000 -0400
 @@ -2,7 +2,10 @@
- 
+
  const users = require('./users/users.service.js');
- 
+
 +const teams = require('./teams/teams.service.js');
 +
  module.exports = function () {
@@ -35,7 +35,7 @@ diff -bdur --new-file 02/gen2/src/services/teams/teams.filters.js 02/gen3/src/se
 +/* eslint no-console: 1 */
 +console.warn('You are using the default filter for the teams service. For more information about event filters see https://docs.feathersjs.com/api/events.html#event-filtering'); // eslint-disable-line no-console
 +
-+module.exports = function (data, connection, hook) { // eslint-disable-line no-unused-vars
++module.exports = function (data, connection, context) { // eslint-disable-line no-unused-vars
 +  return data;
 +};
 diff -bdur --new-file 02/gen2/src/services/teams/teams.hooks.js 02/gen3/src/services/teams/teams.hooks.js

--- a/examples/step/_diff/02-gen4-line.html
+++ b/examples/step/_diff/02-gen4-line.html
@@ -127,7 +127,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return function (hook) {</span>
+            <span class="d2h-code-line-ctn">  return function (context) {</span>
         </div>
     </td>
 </tr><tr>
@@ -149,7 +149,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // that resolves with the `hook` object for asynchronous operations</span>
+            <span class="d2h-code-line-ctn">    // that resolves with the `context` object for asynchronous operations</span>
         </div>
     </td>
 </tr><tr>
@@ -160,7 +160,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    return Promise.resolve(hook);</span>
+            <span class="d2h-code-line-ctn">    return Promise.resolve(context);</span>
         </div>
     </td>
 </tr><tr>
@@ -494,7 +494,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // A mock hook object</span>
+            <span class="d2h-code-line-ctn">    // A mock context object</span>
         </div>
     </td>
 </tr><tr>
@@ -559,7 +559,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // and compare the resulting hook object</span>
+            <span class="d2h-code-line-ctn">    // and compare the resulting context object</span>
         </div>
     </td>
 </tr><tr>
@@ -581,7 +581,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      assert.equal(result, mock, 'Returns the expected hook object');</span>
+            <span class="d2h-code-line-ctn">      assert.equal(result, mock, 'Returns the expected context object');</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/02-gen4-side.html
+++ b/examples/step/_diff/02-gen4-side.html
@@ -58,7 +58,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -66,7 +66,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -74,7 +74,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -82,7 +82,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -90,7 +90,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -98,7 +98,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -106,7 +106,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -114,7 +114,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -122,7 +122,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -130,7 +130,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -138,7 +138,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -146,7 +146,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -231,7 +231,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">  return function (hook) {</span>
+            <span class="d2h-code-line-ctn">  return function (context) {</span>
         </div>
     </td>
 </tr><tr>
@@ -251,7 +251,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // that resolves with the `hook` object for asynchronous operations</span>
+            <span class="d2h-code-line-ctn">    // that resolves with the `context` object for asynchronous operations</span>
         </div>
     </td>
 </tr><tr>
@@ -261,7 +261,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    return Promise.resolve(hook);</span>
+            <span class="d2h-code-line-ctn">    return Promise.resolve(context);</span>
         </div>
     </td>
 </tr><tr>
@@ -340,7 +340,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -348,7 +348,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -651,7 +651,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -659,7 +659,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -667,7 +667,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -675,7 +675,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -683,7 +683,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -691,7 +691,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -699,7 +699,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -707,7 +707,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -715,7 +715,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -723,7 +723,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -731,7 +731,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -739,7 +739,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -747,7 +747,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -755,7 +755,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -763,7 +763,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -771,7 +771,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -779,7 +779,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -787,7 +787,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -795,7 +795,7 @@
     </td>
 </tr><tr>
     <td class="d2h-code-side-linenumber d2h-cntx">
-      
+
     </td>
     <td class="d2h-cntx">
         <div class="d2h-code-side-line d2h-cntx">
@@ -890,7 +890,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // A mock hook object</span>
+            <span class="d2h-code-line-ctn">    // A mock context object</span>
         </div>
     </td>
 </tr><tr>
@@ -949,7 +949,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">    // and compare the resulting hook object</span>
+            <span class="d2h-code-line-ctn">    // and compare the resulting context object</span>
         </div>
     </td>
 </tr><tr>
@@ -969,7 +969,7 @@
     <td class="d2h-ins">
         <div class="d2h-code-side-line d2h-ins">
             <span class="d2h-code-line-prefix">+</span>
-            <span class="d2h-code-line-ctn">      assert.equal(result, mock, 'Returns the expected hook object');</span>
+            <span class="d2h-code-line-ctn">      assert.equal(result, mock, 'Returns the expected context object');</span>
         </div>
     </td>
 </tr><tr>

--- a/examples/step/_diff/02-gen4.diff
+++ b/examples/step/_diff/02-gen4.diff
@@ -8,26 +8,26 @@ diff -bdur --new-file 02/gen3/src/hooks/populate-teams.js 02/gen4/src/hooks/popu
 +// For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
 +
 +module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
-+  return function (hook) {
++  return function (context) {
 +    // Hooks can either return nothing or a promise
-+    // that resolves with the `hook` object for asynchronous operations
-+    return Promise.resolve(hook);
++    // that resolves with the `context` object for asynchronous operations
++    return Promise.resolve(context);
 +  };
 +};
 diff -bdur --new-file 02/gen3/src/services/teams/teams.hooks.js 02/gen4/src/services/teams/teams.hooks.js
 --- 02/gen3/src/services/teams/teams.hooks.js	2017-04-09 09:15:24.638007000 -0400
 +++ 02/gen4/src/services/teams/teams.hooks.js	2017-04-09 09:18:59.418007000 -0400
 @@ -2,6 +2,8 @@
- 
+
  const { authenticate } = require('feathers-authentication').hooks;
- 
+
 +const populateTeams = require('../../hooks/populate-teams');
 +
  module.exports = {
    before: {
      all: [ authenticate('jwt') ],
 @@ -15,7 +17,7 @@
- 
+
    after: {
      all: [],
 -    find: [],
@@ -46,15 +46,15 @@ diff -bdur --new-file 02/gen3/test/hooks/populate-teams.test.js 02/gen4/test/hoo
 +
 +describe('\'populateTeams\' hook', () => {
 +  it('runs the hook', () => {
-+    // A mock hook object
++    // A mock context object
 +    const mock = {};
 +    // Initialize our hook with no options
 +    const hook = populateTeams();
 +
 +    // Run the hook function (which returns a promise)
-+    // and compare the resulting hook object
++    // and compare the resulting context object
 +    return hook(mock).then(result => {
-+      assert.equal(result, mock, 'Returns the expected hook object');
++      assert.equal(result, mock, 'Returns the expected context object');
 +    });
 +  });
 +});

--- a/guides/advanced/debugging.md
+++ b/guides/advanced/debugging.md
@@ -47,10 +47,10 @@ Since [hooks](../../api/hooks.md) can be registered dynamically anywhere in your
 ```js
 const hooks = require('feathers-authentication').hooks;
 
-const myDebugHook = function(hook) {
-  // check to see what is in my hook object after
+const myDebugHook = function(context) {
+  // check to see what is in my context object after
   // the token was verified.
-  console.log(hook);
+  console.log(context);
 };
 
 // Must be logged in do anything with messages.
@@ -64,4 +64,4 @@ app.service('messages').before({
 });
 ```
 
-You can then move that hook around the hook chain and inspect what your `hook` object looks like.
+You can then move that hook around the hook chain and inspect what your `context` object looks like.

--- a/guides/advanced/file-uploading.md
+++ b/guides/advanced/file-uploading.md
@@ -267,11 +267,11 @@ const dauria = require('dauria');
 // with multipart file uploads
 app.service('/uploads').before({
     create: [
-        function(hook) {
-            if (!hook.data.uri && hook.params.file){
-                const file = hook.params.file;
+        function(context) {
+            if (!context.data.uri && context.params.file){
+                const file = context.params.file;
                 const uri = dauria.getBase64DataURI(file.buffer, file.mimetype);
-                hook.data = {uri: uri};
+                context.data = {uri: uri};
             }
         }
     ]

--- a/guides/advanced/using-a-view-engine.md
+++ b/guides/advanced/using-a-view-engine.md
@@ -32,7 +32,7 @@ app.get('/messages', function(req, res, next){
 
 Simple right? We've now rendered a list of messages. All your hooks will get triggered just like they would normally so you can use hooks to pre-filter your data and keep your template rendering routes super tight.
 
-> **ProTip:** If you call a Feathers service "internally" (ie. not over sockets or REST) you won't have a `hook.params.provider` attribute. This allows you to have hooks only execute when services are called externally vs. from your own code. See [bundled hooks](../../api/hooks-common.md) for an example.
+> **ProTip:** If you call a Feathers service "internally" (ie. not over sockets or REST) you won't have a `context.params.provider` attribute. This allows you to have hooks only execute when services are called externally vs. from your own code. See [bundled hooks](../../api/hooks-common.md) for an example.
 
 ## Feathers As A Sub-App
 

--- a/guides/auth/recipe.customize-jwt-payload.md
+++ b/guides/auth/recipe.customize-jwt-payload.md
@@ -36,11 +36,11 @@ app.service('authentication').hooks({
 
       // This hook adds the `test` attribute to the JWT payload by
       // modifying params.payload.
-      hook => {
+      context => {
         // make sure params.payload exists
-        hook.params.payload = hook.params.payload || {}
+        context.params.payload = context.params.payload || {}
         // merge in a `test` property
-        Object.assign(hook.params.payload, {test: 'test'})
+        Object.assign(context.params.payload, {test: 'test'})
       }
     ],
     remove: [

--- a/guides/auth/recipe.customize-response.md
+++ b/guides/auth/recipe.customize-response.md
@@ -28,21 +28,21 @@ The JWT also contains a payload which has a `userId` property.
 Based on the above, you can see that we still authenticate a `user` by default.  In this case, the `user` is what we call the `entity`.  It's the generic name of what is being authenticated.  It's customizable, but that's not covered in this guide.  Instead, let's focus on what it takes to add the user in the login response.
 
 ## Customizing the Login Response
-The `/authentication` endpoint is now a Feathers service.  It uses the `create` method for login and the `remove` method for logout.  Just like with all Feathers services, you can customize the response with the [`hook` API](../../api/hooks.md).  For what we want to do, the important part is the `hook.result`, which becomes the response body.  We can use an `after` hook to customize the `hook.result` to return anything that we want:
+The `/authentication` endpoint is now a Feathers service.  It uses the `create` method for login and the `remove` method for logout.  Just like with all Feathers services, you can customize the response with the [`hook` API](../../api/hooks.md).  For what we want to do, the important part is the `context.result`, which becomes the response body.  We can use an `after` hook to customize the `context.result` to return anything that we want:
 
 ```js
 app.service('/authentication').hooks({
   after: {
     create: [
-      hook => {
-        hook.result.foo = 'bar';
+      context => {
+        context.result.foo = 'bar';
       }
     ]
   }
 });
 ```
 
-After a successful login, the `hook.result` already contains the `accessToken`.  The above example modified the response to look like this:
+After a successful login, the `context.result` already contains the `accessToken`.  The above example modified the response to look like this:
 
 ```js
 {
@@ -52,17 +52,17 @@ After a successful login, the `hook.result` already contains the `accessToken`. 
 ```
 
 ## Accessing the User Entity
-Let's see how to include the `user` in the response, as was done in previous versions.  The `/authentication` service modifies the `hook.params` object to contain the entity object (in this case, the `user`).  With that information, you might have already figured out how to get the user into the response.  It just has to be copied from `hook.params.user` to the `hook.result.user`:
+Let's see how to include the `user` in the response, as was done in previous versions.  The `/authentication` service modifies the `context.params` object to contain the entity object (in this case, the `user`).  With that information, you might have already figured out how to get the user into the response.  It just has to be copied from `context.params.user` to the `context.result.user`:
 
 ```js
 app.service('/authentication').hooks({
   after: {
     create: [
-      hook => {
-        hook.result.user = hook.params.user;
+      context => {
+        context.result.user = context.params.user;
 
         // Don't expose sensitive information.
-        delete hook.result.user.password;
+        delete context.result.user.password;
       }
     ]
   }

--- a/guides/auth/recipe.mixed-auth.md
+++ b/guides/auth/recipe.mixed-auth.md
@@ -98,7 +98,7 @@ Now we need to setup an endpoint to handle both unauthenticated and authenticate
 
 If a `user` record contains `public: true`, then **unauthenticated** users should be able to access it. Let’s see how to use the `iff` and `else` conditional hooks from [`feathers-hooks-common`](../../api/hooks-common.md) to make this happen. Be sure to read the [`iff hook API docs`](../../api/hooks-common.md#iff) and [`else hook API docs`](../../api/hooks-common.md#else) if you haven’t, yet.
 
-We’re going to use the `iff` hook to authenticate users only if a token is in the request. The [`feathers-authentication-jwt` plugin](../../api/authentication/jwt.md), which we used in `src/authentication.js`, includes a token extractor. If a request includes a token, it will automatically be available inside the `hook` object at `hook.params.token`.
+We’re going to use the `iff` hook to authenticate users only if a token is in the request. The [`feathers-authentication-jwt` plugin](../../api/authentication/jwt.md), which we used in `src/authentication.js`, includes a token extractor. If a request includes a token, it will automatically be available inside the `context` object at `context.params.token`.
 
 **src/services/users/users.hooks.js**<br/>
 (This example only shows the `find` method's `before` hooks.)
@@ -113,10 +113,10 @@ module.exports = {
     find: [
       // If a token was included, authenticate it with the `jwt` strategy.
       commonHooks.iff(
-        hook => hook.params.token,
+        context => context.params.token,
         authenticate('jwt')
       // No token was found, so limit the query to include `public: true`
-      ).else( hook => Object.assign(hook.params.query, { public: true }) )
+      ).else( context => Object.assign(context.params.query, { public: true }) )
     ]
   }
 };
@@ -127,7 +127,7 @@ Let’s break down the above example. We setup the `find` method of the `/users`
 
 ```js
 iff(
-  hook => hook.params.token,
+  context => context.params.token,
   authenticate(‘jwt’)
 )
 ```
@@ -135,11 +135,11 @@ iff(
 For this application, the above snippet is equivalent to the snippet, below.
 
 ```js
-hook => {
-  if (hook.params.token) {
+context => {
+  if (context.params.token) {
     return authenticate(‘jwt’)
   } else {
-    return Promise.resolve(hook)
+    return Promise.resolve(context)
   }
 }
 ```
@@ -147,10 +147,10 @@ hook => {
 The `iff` hook is actually more capable than the simple demonstration, above. It can handle an async predicate expression. This would be equivalent to being able to pass a `promise` inside the `if` statement's parentheses. It also allows us to chain an `.else()` statement, which will run if the predicate evaluates to false.
 
 ```js
-.else( hook => Object.assign(hook.params.query, { public: true }) )
+.else( context => Object.assign(context.params.query, { public: true }) )
 ```
 
 The above statement simply adds `public: true` to the query parameters. This limits the query to only find `user` records that have the `public` property set to `true`.
 
 ## Wrapping Up
-With the above code, we’ve successfully setup a `/users` service that responds differently to unauthenticated and authenticated users. We used the `hook.params.token` attribute to either authenticate a user or to limit the search query to only public users. If you become familiar with the [Common Hooks API](../../api/hooks-common.md), you’ll be able to solve almost any authentication puzzle.
+With the above code, we’ve successfully setup a `/users` service that responds differently to unauthenticated and authenticated users. We used the `context.params.token` attribute to either authenticate a user or to limit the search query to only public users. If you become familiar with the [Common Hooks API](../../api/hooks-common.md), you’ll be able to solve almost any authentication puzzle.

--- a/guides/chat/processing.md
+++ b/guides/chat/processing.md
@@ -28,18 +28,18 @@ This will create our hook and wire it up to the service we selected. Now it is t
 // For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // The authenticated user
-    const user = hook.params.user;
+    const user = context.params.user;
     // The actual message text
-    const text = hook.data.text
+    const text = context.data.text
       // Messages can't be longer than 400 characters
       .substring(0, 400)
       // Do some basic HTML escaping
       .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 
     // Override the original data
-    hook.data = {
+    context.data = {
       text,
       // Set the user id
       userId: user._id,
@@ -48,8 +48,8 @@ module.exports = function() {
     };
 
     // Hooks can either return nothing or a promise
-    // that resolves with the `hook` object for asynchronous operations
-    return Promise.resolve(hook);
+    // that resolves with the `context` object for asynchronous operations
+    return Promise.resolve(context);
   };
 };
 ```
@@ -61,7 +61,7 @@ This will do several things:
   - The new truncated and sanitized text
   - The currently authenticated user (so we always know who sent it)
   - The current (creation) date 
-3. Return a Promise that resolves with the hook object (this is what any hook should return)
+3. Return a Promise that resolves with the context object (this is what any hook should return)
 
 
 ## Adding a user avatar
@@ -98,17 +98,17 @@ const gravatarUrl = 'https://s.gravatar.com/avatar';
 const query = 's=60';
 
 module.exports = function() {
-  return function(hook) {
+  return function(context) {
     // The user email
-    const { email } = hook.data;
+    const { email } = context.data;
     // Gravatar uses MD5 hashes from an email address to get the image
     const hash = crypto.createHash('md5').update(email).digest('hex');
 
-    hook.data.avatar = `${gravatarUrl}/${hash}?${query}`;
+    context.data.avatar = `${gravatarUrl}/${hash}?${query}`;
 
     // Hooks can either return nothing or a promise
-    // that resolves with the `hook` object for asynchronous operations
-    return Promise.resolve(hook);
+    // that resolves with the `context` object for asynchronous operations
+    return Promise.resolve(context);
   };
 };
 ```

--- a/guides/offline-first/configure-publication.md
+++ b/guides/offline-first/configure-publication.md
@@ -40,7 +40,7 @@ The server-side filtering for offline-first generally needs to look at
 both the previous and the new contents of the record,
 to see if it used to belong or if it now belongs to the publication.
 
-You can stash the current value of a record inside the hook object, before mutating it, with:
+You can stash the current value of a record inside the context object, before mutating it, with:
 ```javascript
 module.exports = {
   before: {

--- a/guides/step-by-step/basic-feathers/hooks-1.md
+++ b/guides/step-by-step/basic-feathers/hooks-1.md
@@ -54,7 +54,7 @@ function user() {
       validateSchema(userSchema(), Ajv), authHooks.hashPassword(), setCreatedAt(), setUpdatedAt()
     ]});
   userService.after({
-    all: unless(hook => hook.method === 'find', remove('password')),
+    all: unless(context => context.method === 'find', remove('password')),
   });
 }
 
@@ -140,10 +140,10 @@ These hooks add `createdAt` and `updatedAt` properties to the data.
 These hooks are run after the operation on the database.
 They act on all the results returned by the operation.
 
-### - unless(hook => hook.method === 'find', remove('password'))
+### - unless(context => context.method === 'find', remove('password'))
 
-- `hook => hook.method === 'find'` returns true if the database operation was a `find`.
-All hooks are passed a [hook object](../../../api/hooks.md#hook-objects)
+- `context => context.method === 'find'` returns true if the database operation was a `find`.
+All hooks are passed a [context object](../../../api/hooks.md#hook-objects)
 which contains information about the operation.
 
 - `remove('password')`

--- a/guides/step-by-step/basic-feathers/hooks-2.md
+++ b/guides/step-by-step/basic-feathers/hooks-2.md
@@ -37,7 +37,7 @@ const {
 } = commonHooks;
 // ...
 userService.before({
-    all: when(hook => hook.method !== 'find', softDelete()), // new
+    all: when(context => context.method !== 'find', softDelete()), // new
     create: [ /* ... */ ]
 });
 ```

--- a/guides/step-by-step/basic-feathers/testing-hooks.md
+++ b/guides/step-by-step/basic-feathers/testing-hooks.md
@@ -127,33 +127,33 @@ describe('services pluck', () => {
     });
 
     it('does not throw if field is missing', () => {
-      const hook = {
+      const context = {
         type: 'before',
         method: 'create',
         params: { provider: 'rest' },
         data: { first: 'John', last: 'Doe' } };
-      hooks.pluck('last', 'xx')(hook);
-      assert.deepEqual(hook.data, { last: 'Doe' });
+      hooks.pluck('last', 'xx')(context);
+      assert.deepEqual(context.data, { last: 'Doe' });
     });
 
     it('does not throw if field is undefined', () => {
-      const hook = {
+      const context = {
         type: 'before',
         method: 'create',
         params: { provider: 'rest' },
         data: { first: undefined, last: undefined } };
-      hooks.pluck('first')(hook);
-      assert.deepEqual(hook.data, {}); // todo note this
+      hooks.pluck('first')(context);
+      assert.deepEqual(context.data, {}); // todo note this
     });
 
     it('does not throw if field is null', () => {
-      const hook = {
+      const context = {
         type: 'before',
         method: 'create',
         params: { provider: 'rest' },
         data: { first: null, last: null } };
-      hooks.pluck('last')(hook);
-      assert.deepEqual(hook.data, { last: null });
+      hooks.pluck('last')(context);
+      assert.deepEqual(context.data, { last: null });
     });
   });
 });

--- a/guides/step-by-step/basic-feathers/writing-hooks.md
+++ b/guides/step-by-step/basic-feathers/writing-hooks.md
@@ -163,9 +163,9 @@ export default function (...fieldNames) {
 ```
 
 The [`getItems` utility](../../../api/hooks-common.md#util-getitems-replaceitems)
-returns the items in either `hook.data` or `hook.result`
+returns the items in either `context.data` or `context.result`
 depending on whether the hook is being used as a before or after hook.
-`hook.result.data` or `hook.result` is returned for a `find` method.
+`context.result.data` or `context.result` is returned for a `find` method.
 
 The returned items are always an array to simplify further processing.
 
@@ -237,11 +237,11 @@ export default function (cache) {
 };
 ```
 
-Feathers will not make the database call if `hook.result` is set.
+Feathers will not make the database call if `context.result` is set.
 Any remaining before and after hooks are still run.
 
 Should this hook find a cached record,
-placing it in `hook.result` is the same as if the database had returned the record.
+placing it in `context.result` is the same as if the database had returned the record.
 
 This example
 - Shows how `before` hooks can determine the result for the call.
@@ -481,7 +481,7 @@ You can combine predicates provided with the common hooks, such as `isProvider`
 You can write your own, or mix and match.
 
 ```javascript
-iff (hook => !isProvider('service')(hook) && hook.params.user.security >= 3, ...)
+iff (context => !isProvider('service')(context) && context.params.user.security >= 3, ...)
 ```
 
 The `isNot` conditional utility


### PR DESCRIPTION
I went through the whole docs repo and tried my best to rename all `hook`s as the object name to `context`  while keeping `hook`s as function name untouched. You guys might need to take some time to review this PR to see if there are any mistakes. :)