### PR TITLE
Small typo in client require

### DIFF
--- a/migrating.md
+++ b/migrating.md
@@ -267,7 +267,7 @@ __Now__
 
 ```js
 const io = require('socket.io-client');
-const feathers = require('@feathers/feathers');
+const feathers = require('@feathersjs/feathers');
 const socketio = require('@feathersjs/socketio-client');
 const auth = require('@feathersjs/authentication-client');
 


### PR DESCRIPTION
Copying code results in an error due to small typo.   Adjusted to find correct package.