### PR TITLE
Add extension to executable JS.

### DIFF
--- a/guides/step-by-step/basic-feathers/rest-client.md
+++ b/guides/step-by-step/basic-feathers/rest-client.md
@@ -10,7 +10,7 @@ Let's write a JavaScript frontend for it.
 [common/public/rest.html](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/common/public/rest.html)
 and
 [feathers-app.js](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/common/public/feathers-app.js)
-- Start the server: `node ./examples/step/01/rest/2`
+- Start the server: `node ./examples/step/01/rest/2.js`
 - Point the browser at: `localhost:3030/rest.html`
 - Compare with last page's server
 [examples/step/01/rest/1.js](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/rest/1.js):


### PR DESCRIPTION
It might seems confusing to some (like myself just now) to have the server file here without the `.js` extension. While it runs fine I feel the guide will benefit from being easy to understand and keeping to a convention of explicitly stating file endings in node calls.