### PR TITLE
Explicitly mention Feathers error module install

### DIFF
--- a/guides/basics/hooks.md
+++ b/guides/basics/hooks.md
@@ -139,7 +139,15 @@ app.service('messages').hooks(messagesHooks);
 
 ## Validating data
 
-If a hook throws an error, all following hooks will be skipped and the error will be returned to the user. This makes `before` hooks a great place to validate incoming data by throwing an error for invalid data. We can throw a normal [JavaScript error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) or [Feathers error](../../api/errors.md) which has some additional functionality (like returning the proper error code for REST calls). We will only need the hook for `create`, `update` and `patch` since those are the only service methods that allow user submitted data:
+If a hook throws an error, all following hooks will be skipped and the error will be returned to the user. This makes `before` hooks a great place to validate incoming data by throwing an error for invalid data. We can throw a normal [JavaScript error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) or [Feathers error](../../api/errors.md) which has some additional functionality (like returning the proper error code for REST calls). 
+
+Feathers error is a separate module, so you must add it to your project before requiring it:
+
+```bash
+npm install @feathersjs/errors --save
+```
+
+We will only need the hook for `create`, `update` and `patch` since those are the only service methods that allow user submitted data:
 
 ```js
 const { BadRequest } = require('@feathersjs/errors');


### PR DESCRIPTION
The code sample under hooks will not compile without the reader first installing the Feathers error module. This makes that explicit and avoids an error on first run.