### PR TITLE
eliminate 'localhost' from website scripts

### DIFF
--- a/guides/basics/real-time.md
+++ b/guides/basics/real-time.md
@@ -152,7 +152,7 @@ Then we can initialize and use the socket directly making some calls and listeni
 /* global io */
 
 // Create a websocket connecting to our Feathers server
-const socket = io('http://localhost:3030');
+const socket = io(':3030') ;  //  or use io('http://localhost:3030');
 
 // Listen to new messages being created
 socket.on('messages created', message =>


### PR DESCRIPTION
when running over a network, the value of "localhost" has to be constantly changed, which is way too easy to forget for a newbie.

same change would be in in https://docs.feathersjs.com/guides/basics/clients.html