### PR TITLE
Fixed the parameters shown in example.

### DIFF
--- a/api/channels.md
+++ b/api/channels.md
@@ -341,7 +341,7 @@ const updateChannels = user => {
 app.on('login', (payload, { connection }) => {
   if(connection) {
     // Join all channels on login
-    joinChannels(user, connection.user);
+    joinChannels(connection.user, connection);
   }
 });
 


### PR DESCRIPTION
As per the definition of `joinChannels`, parameters should be `user` and `connection`. Corrected the same in docs.