### PR TITLE
Fix broken inline hook execution diagram.

### DIFF
--- a/guides/basics/hooks.md
+++ b/guides/basics/hooks.md
@@ -130,12 +130,12 @@ const messagesHooks = {
   }
 };
 
+app.service('messages').hooks(messagesHooks);
+```
+
 This diagram illustrates when each hook will be executed:
 
 ![Hook flow](./assets/hook-flow.jpg)
-
-app.service('messages').hooks(messagesHooks);
-```
 
 ## Validating data
 


### PR DESCRIPTION
The hook execution diagram is appearing as inline code in the example code above it:

![https://i.nick.sg/8fa4690e35454789b783876610c0d19e.png](https://i.nick.sg/8fa4690e35454789b783876610c0d19e.png)

This change fixes that and embeds the diagram properly.