### PR TITLE
Add missing default options

### DIFF
--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -53,6 +53,8 @@ This will pull from your global authentication object in your config file. It wi
     service: 'users', // the service to look up the entity
     usernameField: 'email', // key name of username field
     passwordField: 'password', // key name of password field
+    entityUsernameField: 'email', // key name of the username field on the entity (defaults to `usernameField`) 
+    entityPasswordField: 'password', // key name of the password on the entity (defaults to `passwordField`) 
     passReqToCallback: true, // whether the request object should be passed to `verify`
     session: false // whether to use sessions,
     Verifier: Verifier // A Verifier class. Defaults to the built-in one but can be a custom one. See below for details.


### PR DESCRIPTION
In a company project we recently had a bug that came down to the entityUsernameField's default value. I noticed that in the deprecated feathers-authentication-local package these options are documented. Also confirmed that the authentication-local plugin still checks for the presence of entity*Field options.