### PR TITLE
Why bother with returning & async on hooks

### DIFF
--- a/guides/basics/hooks.md
+++ b/guides/basics/hooks.md
@@ -19,10 +19,8 @@ Here is a quick example for a hook that adds a `createdAt` property to the data 
 ```js
 app.service('messages').hooks({
   before: {
-    create: async context => {
+    create (context) {
       context.data.createdAt = new Date();
-
-      return context;
     }
   }
 })


### PR DESCRIPTION
Why bother with returning and async on hooks? The document is really vague on that. A diverse set of examples is more helpful to show alternatives.

Furthermore, the async examples should have legitimate async steps to justify them.