### PR TITLE
Fix reference to env-specific config file

### DIFF
--- a/api/configuration.md
+++ b/api/configuration.md
@@ -66,7 +66,7 @@ In `config/default.json` we want to use the local development environment and de
 }
 ```
 
-In `config/production.js` we are going to use environment variables (e.g. set by Heroku) and use `public/dist` to load the frontend production build:
+In `config/production.json` we are going to use environment variables (e.g. set by Heroku) and use `public/dist` to load the frontend production build:
 
 ```js
 {


### PR DESCRIPTION
It mentions the file as ` .js` but it's actually a json file.
(otoh, it'd be amazing to have a js configuration example in this page).