### PR TITLE
Change function to middleware in options docs

### DIFF
--- a/api/authentication/oauth2.md
+++ b/api/authentication/oauth2.md
@@ -72,9 +72,9 @@ Registering the OAuth2 plugin will automatically set up routes to handle the OAu
     service: 'users', // the service to look up the entity
     passReqToCallback: true, // whether the request object should be passed to `verify`
     session: false, // whether to use sessions,
-    handler: function, // Express middleware for handling the oauth callback. Defaults to the built in middleware.
-    errorHandler: function, // Express middleware for handling errors. Defaults to the built in middleware.
-    formatter: function, // The response formatter. Defaults the the built in feathers-rest formatter, which returns JSON.
+    handler: middleware, // Express middleware for handling the oauth callback. Defaults to the built in middleware.
+    errorHandler: middleware, // Express middleware for handling errors. Defaults to the built in middleware.
+    formatter: middleware, // The response formatter middleware. Defaults to the the built in feathers-rest formatter, handling only JSON.
     Verifier: Verifier // A Verifier class. Defaults to the built-in one but can be a custom one. See below for details.
 }
 ```


### PR DESCRIPTION
In the documentation renderer, `function` breaks syntax highlighting.
Middleware is a common term for Express developers, though we might want to hint at the signature `(req, res, next) => {}` or `(err, req, res, next) => {}`.
It's an improvement over `function` anyway.