### PR TITLE
Remove query reference from params

### DIFF
--- a/guides/chat/processing.md
+++ b/guides/chat/processing.md
@@ -143,9 +143,9 @@ module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
     // Asynchronously get user object from each message's `userId`
     // and add it to the message
     await Promise.all(messages.map(async message => {
-      // Also pass the original `params` to the service call
+      // Also pass the original `params` to the service call, minus the query
       // so that it has the same information available (e.g. who is requesting it)
-      message.user = await app.service('users').get(message.userId, params);
+      message.user = await app.service('users').get(message.userId, Object.assign(params, {query: ""}));
     }));
 
     // Best practice: hooks should always return the context


### PR DESCRIPTION
Query isn't relevant for the the get method in `populate-user.js` and can cause errors. In my case specifically, I followed step-by-step, except I used sequelize with MySQL. 

When this call is made client side in `app.js`:
```
const messages = await client.service('messages').find({
    query: {
      $sort: { createdAt: -1 },
      $limit: 25
    }
  });
```

`populate-user.js` then passes that query object to the users service (included in params), which would in turn product this an error:

```
{code: "ER_BAD_FIELD_ERROR", errno: 1054, sqlState: "42S22", sqlMessage: "Unknown column 'users.$limit
```

I think its best we let users know that its best practices to omit the query reference, to avoid issues like this.