### PR TITLE
Fix documentation error about local.hooks.protect

### DIFF
--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -95,11 +95,7 @@ The protect hook makes sure that protected fields don't get sent to a client.
 const local = require('@feathersjs/authentication-local');
 
 app.service('users').hooks({
-  after: {
-    create: [
-      local.hooks.protect('password')
-    ]
-  }
+  after: local.hooks.protect('password')
 });
 ```
 


### PR DESCRIPTION
The password field didn't get protected in the documentation example.

The local.hooks.protect hook must be an global after hook and not an after.create one.
The [feathersjs-authentication README](https://github.com/feathersjs/authentication/blob/master/README.md) is already correct but this documentation was not.