### PR TITLE
Fix curl for scaffolded service

### DIFF
--- a/guides/chat/service.md
+++ b/guides/chat/service.md
@@ -44,7 +44,7 @@ We can go to [localhost:3030/messages](http://localhost:3030/messages) and will 
 We can also `POST` new messages and `PUT`, `PATCH` and `DELETE` existing messages (via `/messages/<_id>`), for example from the command line using [CURL](https://curl.haxx.se/):
 
 ```
-curl 'http://localhost:3030/messages/' -H 'Content-Type: application/json' --data-binary '{ "name": "Curler", "text": "Hello from the command line!" }'
+curl 'http://localhost:3030/messages/' -H 'Content-Type: application/json' --data-binary '{ "text": "Hello from the command line!" }'
 ```
 
 Or with a REST client, e.g. [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en), using this button:


### PR DESCRIPTION
The curl had a name field which the scaffolded `messages` service does not have. Fix the curl.