### PR TITLE
Use vuepress tabs plugin and replace gitbook codetabs usages

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -111,5 +111,5 @@ module.exports = {
       }
     ]
   },
-  plugins: ['@vuepress/last-updated']
-}
+  plugins: ['@vuepress/last-updated', 'tabs']
+};

--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -1,0 +1,1 @@
+@require '~vuepress-plugin-tabs/dist/themes/default.styl'

--- a/api/client/primus.md
+++ b/api/client/primus.md
@@ -46,7 +46,10 @@ The `@feathersjs/primus-client` module allows to connect to services exposed thr
 
 Initialize the Primus client using a given socket and the default options.
 
-{% codetabs name="Modular", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Modular"
+``` javascript
 const feathers = require('@feathersjs/feathers');
 const primusClient = require('@feathersjs/primus-client');
 const socket = new Primus('http://api.my-feathers-server.com');
@@ -63,7 +66,11 @@ app.service('messages')
 app.service('messages').create({
   text: 'A message from a REST client'
 });
-{%- language name="@feathersjs/client", type="html" -%}
+```
+:::
+
+::: tab "@feathersjs/client"
+``` html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
 <script src="//unpkg.com/@feathersjs/client@^3.0.0/dist/feathers.js"></script>
 <script type="text/javascript" src="primus/primus.js"></script>
@@ -84,7 +91,10 @@ app.service('messages').create({
     text: 'A message from a REST client'
   });
 </script>
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 ### `primus(socket, options)`
 

--- a/api/client/rest.md
+++ b/api/client/rest.md
@@ -26,7 +26,10 @@ $ npm install @feathersjs/rest-client --save
 
 REST client services can be initialized by loading `@feathersjs/rest-client` and initializing a client object with a base URL:
 
-{% codetabs name="Modular", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Modular"
+``` javascript
 const feathers = require('@feathersjs/feathers');
 const rest = require('@feathersjs/rest-client');
 
@@ -43,7 +46,11 @@ app.configure(restClient.fetch(window.fetch));
 
 // Connect to the `http://feathers-api.com/messages` service
 const messages = app.service('messages');
-{%- language name="@feathersjs/client", type="html" -%}
+```
+:::
+
+::: tab "@feathersjs/client"
+``` html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
 <script src="//unpkg.com/@feathersjs/client@^3.0.0/dist/feathers.js"></script>
 <script>
@@ -57,7 +64,10 @@ const messages = app.service('messages');
   // Connect to the `http://feathers-api.com/messages` service
   const messages = app.service('messages');
 </script>
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 <!-- -->
 

--- a/api/client/socketio.md
+++ b/api/client/socketio.md
@@ -20,7 +20,10 @@ The `@feathersjs/socketio-client` module allows to connect to services exposed t
 
 Initialize the Socket.io client using a given socket and the default options.
 
-{% codetabs name="Modular", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Modular"
+``` javascript
 const feathers = require('@feathersjs/feathers');
 const socketio = require('@feathersjs/socketio-client');
 const io = require('socket.io-client');
@@ -39,7 +42,11 @@ app.service('messages')
 app.service('messages').create({
   text: 'A message from a REST client'
 });
-{%- language name="@feathersjs/client", type="html" -%}
+```
+:::
+
+::: tab "@feathersjs/client"
+``` html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
 <script src="//unpkg.com/@feathersjs/client@^3.0.0/dist/feathers.js"></script>
 <script src="//unpkg.com/socket.io-client@1.7.3/dist/socket.io.js"></script>
@@ -63,7 +70,10 @@ app.service('messages').create({
 
   // feathers.errors is an object with all of the custom error types.
 </script>
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 
 ### socketio(socket, options)

--- a/api/services.md
+++ b/api/services.md
@@ -6,7 +6,10 @@
 
 Service methods are pre-defined [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) methods that your service object can implement (or that have already been implemented by one of the [database adapters](./databases/common.md)). Below is a complete example of the Feathers *service interface* as a normal JavaScript object either returning a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) or using [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function):
 
-{% codetabs name="Promise", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Promise"
+``` javascript
 const myService = {
   find(params) {
     return Promise.resolve([]);
@@ -20,7 +23,11 @@ const myService = {
 }
 
 app.use('/my-service', myService);
-{%- language name="async/await", type="js" -%}
+```
+:::
+
+::: tab "async/await"
+``` javascript
 const myService = {
   async find(params) {
     return [];
@@ -34,11 +41,17 @@ const myService = {
 }
 
 app.use('/my-service', myService);
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 Services can also be an instance of an [ES6 class](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes):
 
-{%- codetabs name="Promise", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Promise"
+``` javascript
 class MyService {
   find(params) {
     return Promise.resolve([]);
@@ -52,7 +65,11 @@ class MyService {
 }
 
 app.use('/my-service', new MyService());
-{%- language name="async/await", type="js" -%}
+```
+:::
+
+::: tab "async/await"
+``` javascript
 class MyService {
   async find(params) {
     return [];
@@ -66,7 +83,10 @@ class MyService {
 }
 
 app.use('/my-service', new MyService());
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 > **ProTip:** Methods are optional, and if a method is not implemented Feathers will automatically emit a `NotImplemented` error.
 

--- a/guides/basics/services.md
+++ b/guides/basics/services.md
@@ -25,7 +25,10 @@ Service methods are [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_an
 
 Below is an example of Feathers service interface as a normal object and a JavaScript class:
 
-{% codetabs name="Object", type="js" -%}
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Object"
+``` javascript
 const myService = {
   async find(params) {
     return [];
@@ -38,7 +41,11 @@ const myService = {
 }
 
 app.use('/my-service', myService);
-{%- language name="Class", type="js" -%}
+```
+:::
+
+::: tab "Class"
+``` javascript
 class myService {
   async find(params) {
     return [];
@@ -51,7 +58,10 @@ class myService {
 }
 
 app.use('/my-service', new myService());
-{%- endcodetabs %}
+```
+:::
+
+::::
 
 The parameters for service methods are:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5018,8 +5018,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5040,14 +5039,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5062,20 +5059,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5192,8 +5186,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5205,7 +5198,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5220,7 +5212,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5228,14 +5219,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5254,7 +5243,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5335,8 +5323,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5348,7 +5335,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5434,8 +5420,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5471,7 +5456,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5491,7 +5475,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5535,14 +5518,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -13110,6 +13091,12 @@
         "loader-utils": "^1.0.2"
       }
     },
+    "vue-tabs-component": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vue-tabs-component/-/vue-tabs-component-1.5.0.tgz",
+      "integrity": "sha512-ld4p+hv49Fimw+zv/7GQqMhbjAHjpbWF3UiJtmMaSnvLKbsB1ysfs9dQH0SZ8NvdYpqqKay/VLIqR9yXgse1Sg==",
+      "dev": true
+    },
     "vue-template-compiler": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
@@ -13186,6 +13173,12 @@
       "requires": {
         "markdown-it-container": "^2.0.0"
       }
+    },
+    "vuepress-plugin-tabs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-tabs/-/vuepress-plugin-tabs-0.2.2.tgz",
+      "integrity": "sha512-PqC1/Qf84klDTlfDr5Hb3WRsS/NJAicYroYxqdhi8uVwhiCiHXeK/ehs+glYaQd9NRSG7z2AT5mKHCxRVzKayA==",
+      "dev": true
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "remark-validate-links": "^8.0.2",
     "unified-engine": "^6.0.1",
     "vfile-reporter": "^5.1.1",
-    "vuepress": "^1.0.0-alpha.23"
+    "vue-tabs-component": "^1.5.0",
+    "vuepress": "^1.0.0-alpha.23",
+    "vuepress-plugin-tabs": "^0.2.2"
   }
 }


### PR DESCRIPTION
In the crow docs there are still codeblocks from the old gitbook that are "breaking" the documentation.

I added an existent vuepress plugin to add tab support and used it to replace all occurences of codeblocks.

I did not add any additional styling.