### PR TITLE
Fix Docs Indentation

### DIFF
--- a/api/authentication/server.md
+++ b/api/authentication/server.md
@@ -110,8 +110,8 @@ These properties can be modified to change the behavior of the `/authentication`
 
 - `payload {Object}` - becomes the JWT payload. Will also include an `exp` property denoting the expiry timestamp.
 - `options {Object}` - the options passed to [jsonwebtoken `sign()`](https://www.npmjs.com/package/jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
- - `secret {String | Buffer}` - either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
- - `jwt` - See the [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback) package docs for other available options. The authenticate method uses the [default `jwt` options](#default-options). When using this package directly, they have to be passed in manually.
+  - `secret {String | Buffer}` - either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
+  - `jwt` - See the [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback) package docs for other available options. The authenticate method uses the [default `jwt` options](#default-options). When using this package directly, they have to be passed in manually.
 
 The returned `promise` resolves with the JWT or fails with an error.
 


### PR DESCRIPTION
The docs use a single space indentation which is misleading when viewing in the github markdown preview. `jwt` and `secret` are children of `options`, but appear as siblings because there's only 1 space instead of 2 of indentation.