### PR TITLE
Fixed Typo in Authentication guide md file

### DIFF
--- a/guides/basics/authentication.md
+++ b/guides/basics/authentication.md
@@ -112,7 +112,7 @@ When using Feathers on the client, the authentication client does all those auth
 </html>
 ```
 
-In `public/app.js` we can now set up the Feathers client similar to the [getting started example](./starting.md). We also add a `login` method that first tries to use a stored token by calling `app.reAuthenticate()`. If that fails, we try to log in with email/password of our registered user:
+In `src/app.js` we can now set up the Feathers client similar to the [getting started example](./starting.md). We also add a `login` method that first tries to use a stored token by calling `app.reAuthenticate()`. If that fails, we try to log in with email/password of our registered user:
 
 ```js
 // Establish a Socket.io connection


### PR DESCRIPTION
I believe the wording public/app.js was a typo and that it should be src/app.js in the Browser Authentication section of the Authentication guide md file. There is not a app.js file within the public folder of the generated feathers project when following the guide to my knowledge