### PR TITLE
update FacebookStrategy class name

### DIFF
--- a/cookbook/authentication/facebook.md
+++ b/cookbook/authentication/facebook.md
@@ -52,7 +52,7 @@ In `src/authentication.js`:
 const axios = require('axios');
 const { OAuthStrategy } = require('@feathersjs/authentication-oauth');
 
-class FacebookOAuth extends OAuthStrategy {
+class FacebookStrategy extends OAuthStrategy {
   async getProfile (authResult) {
     // This is the oAuth access token that can be used
     // for Facebook API requests as the Bearer token
@@ -102,7 +102,7 @@ import { OAuthStrategy, OAuthProfile } from '@feathersjs/authentication-oauth';
 import axios from 'axios';
 import { Application } from './declarations';
 
-class FacebookOAuth extends OAuthStrategy {
+class FacebookStrategy extends OAuthStrategy {
   async getProfile (data: AuthenticationRequest, _params: Params) {
     // This is the oAuth access token that can be used
     // for Facebook API requests as the Bearer token


### PR DESCRIPTION
Class name instantiated is not the same name as the one used to define the class.