### PR TITLE
Improve authentication backwards compatibility

### DIFF
--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -343,7 +343,7 @@ class MyAuthenticationService extends AuthenticationService {
 
     return {
       ...payload,
-      userId: user.id
+      userId: user.id || user._id 
     };
   }
 }


### PR DESCRIPTION
When using e.g. feather-mongoose the id-Field is "_id".