### PR TITLE
Clarify info about real-time events

### DIFF
--- a/api/client/rest.md
+++ b/api/client/rest.md
@@ -15,7 +15,7 @@ $ npm install @feathersjs/rest-client --save
 
 <!-- -->
 
-> **ProTip:** REST client services do emit `created`, `updated`, `patched` and `removed` events but only _locally for their own instance_. Real-time events from other clients can only be received by using a websocket connection.
+> **ProTip:** REST client services do emit `created`, `updated`, `patched` and `removed` events but only _locally for their own instance_. Real-time events from other clients can only be received by using a real-time transport ([Socket.io](./socketio.md) or [Primus](./primus.md)).
 
 <!-- -->
 


### PR DESCRIPTION
This part of the documentation was a little misleading. You DON'T need a websocket setup to be able to receive real-time events from the server. The real-time transports via socketio or primus can fallback to http polling in the cases when a websocket connection can not be established. So you can use a realtime transport even if you have some proxy or some other kind network restriction that won't allow a websocket connection.