### PR TITLE
Changed ts-node Command in Getting Started

### DIFF
--- a/guides/basics/starting.md
+++ b/guides/basics/starting.md
@@ -376,7 +376,7 @@ node app.js
 :::
 ::: tab "TypeScript"
 ```sh
-ts-node app.ts
+ts-node index.ts
 ```
 :::
 ::::


### PR DESCRIPTION
Used the `ts-node` command that enable me to start the API when using Feathers `4.3.7`.