### PR TITLE
Clarify the note on calling `app.reAuthenticate()`

### DIFF
--- a/api/authentication/client.md
+++ b/api/authentication/client.md
@@ -51,7 +51,7 @@ app.reAuthenticate().then(() => {
 });
 ```
 
-> __Important:__ `app.reAuthenticate()` has to be called when you want to use the token from storage and __only once__ when the application initializes. Once successful, all subsequent requests will send their authentication information automatically.
+> __Important:__ `app.reAuthenticate()` has to be called when you want to use the token from storage. __There’s no need to call it more than once__, so you’d typically only do it when the application initializes. Once successful, all subsequent requests will send their authentication information automatically. In some rare cases, for example making sure the user object returned by `app.get('authentication')` is up-to-date after it was changed on the server, you may safely call it again.
 
 
 ## app.authenticate(data)


### PR DESCRIPTION
As discussed [here](https://github.com/feathersjs/docs/issues/1397), this pull request attempts to clarify that it’s safe to call `app.reAuthenticate()` if necessary, but it shouldn’t be called for _every_ request and only very rarely needs to be called more than  once.

Closes https://github.com/feathersjs/docs/issues/1397