### PR TITLE
Remove NeDB reference in code snippets for file uploads

### DIFF
--- a/cookbook/express/file-uploading.md
+++ b/cookbook/express/file-uploading.md
@@ -74,11 +74,6 @@ Let's look at this implemented in the `@feathersjs/cli` generated server code:
 
 // Initializes the `uploads` service on path `/uploads'
 
-
-// Here we used the nedb database, but you can
-// use any other ORM database.
-const createService = require('feathers-nedb');
-
 const createModel = require('../../models/uploads.model');
 const hooks = require('./uploads.hooks');
 const filters = require('./uploads.filters');


### PR DESCRIPTION
The Feathers cookbook for file uploads includes a code snippet where NeDB is imported, alongside an explanation for doing so. However, the dependency is never used and may cause confusion to users. It threw me for a bit of a loop. 😅

If this snippet does indeed belong here - perhaps we could refactor to make it more clear where it is necessary? I'd be more than happy to submit an updated PR if this is the case. 👍