### PR TITLE
Corrected typo for windows users

### DIFF
--- a/guides/basics/testing.md
+++ b/guides/basics/testing.md
@@ -61,7 +61,7 @@ Now we can update the `scripts` section of our `package.json` to the following:
 On Windows the `mocha` command should look like this:
 
 ```sh
-npm run clean & SET NODE_ENV=test & mocha test/ --recursive --exit
+npm run clean & SET NODE_ENV=test& mocha test/ --recursive --exit
 ```
 
 This will make sure that the `test/data` folder is removed before every test run and `NODE_ENV` is set properly.


### PR DESCRIPTION
Relates to https://github.com/feathersjs/docs/issues/1452 
Having a space before the & adds that space at the end of the variable. The NODE_ENV is then set to "test " which is unexpected.