### PR TITLE
Fixing param name at FacebookStrategy TS

### DIFF
--- a/cookbook/authentication/facebook.md
+++ b/cookbook/authentication/facebook.md
@@ -104,7 +104,7 @@ import axios from 'axios';
 import { Application } from './declarations';
 
 class FacebookStrategy extends OAuthStrategy {
-  async getProfile (data: AuthenticationRequest, _params: Params) {
+  async getProfile (authResult: AuthenticationRequest, _params: Params) {
     // This is the oAuth access token that can be used
     // for Facebook API requests as the Bearer token
     const accessToken = authResult.access_token;


### PR DESCRIPTION
### What this PR do?

 fixes the param name at `FacebookStrategy` `get profile` function:

When I was reading the docs, just copied the snippet `FacebookStrategy` from the TS docs, suddenly I found this inconsistency this PR

### The problem:

- Duplicated identifier (`data`) 
- Also `authResult` does not exists in this scope

<img width="581" alt="authentication ts — scrimmage-api 2020-04-06 01-11-13" src="https://user-images.githubusercontent.com/36987863/78522373-987e2580-77a3-11ea-8342-55617d7f62e3.png">

### On docs:

![Facebook | FeathersJS 2020-04-06 01-15-09](https://user-images.githubusercontent.com/36987863/78522547-26f2a700-77a4-11ea-8f0e-dd0dfc642aa2.png)
