### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -2,6 +2,10 @@ module.exports = {
   title: 'FeathersJS',
   description: 'A REST and real-time API layer for modern applications',
   themeConfig: {
+    algolia: {
+      apiKey: 'feathersjs',
+      indexName: 'feathersjs'
+    },
     logo: '/img/feathers-logo-wide.png',
     repo: 'feathersjs/feathers',
     docsRepo: 'feathersjs/docs',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.