### PR TITLE
Update the repo address for Feathers + Vue integration

### DIFF
--- a/guides/frameworks.md
+++ b/guides/frameworks.md
@@ -15,7 +15,7 @@ The [Feathers Chat application](../guides/) from guide gives a basic intro to us
 - React: [feathersjs-ecosystem/feathers-chat-react](https://github.com/feathersjs-ecosystem/feathers-chat-react)
 - React Native: [feathersjs-ecosystem/feathers-react-native-chat](https://github.com/feathersjs-ecosystem/feathers-react-native-chat)
 - Angular: [feathersjs-ecosystem/feathers-chat-angular](https://github.com/feathersjs-ecosystem/feathers-chat-angular)
-- VueJS with Vuex: [feathers-plus/feathers-chat-vuex](https://github.com/feathers-plus/feathers-chat-vuex)
+- VueJS with Vuex: [feathersjs-ecosystem/feathers-chat-vuex](https://github.com/feathersjs-ecosystem/feathers-chat-vuex)
 
 ## Examples
 


### PR DESCRIPTION
The current link for Vue integration leads to https://github.com/feathers-plus/feathers-chat-vuex repository which is outdated and not maintained anymore. The recent repo for the current version of FeathersVuex is at https://github.com/feathersjs-ecosystem/feathers-chat-vuex.