### PR TITLE
fix(code): remove dollar prompt from command code blocks

### DIFF
--- a/api/application.md
+++ b/api/application.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/feathers/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/feathers --save
+npm install @feathersjs/feathers --save
 ```
 
 The core `@feathersjs/feathers` module provides the ability to initialize a new Feathers application instance. It works in Node, React Native and the browser (see the [client](./client.md) chapter for more information). Each instance allows for registration and retrieval of [services](./services.md), [hooks](./hooks.md), plugin configuration, and getting and setting configuration options. An initialized Feathers application is referred to as the **app object**.

--- a/api/authentication/jwt.md
+++ b/api/authentication/jwt.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/authentication/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/authentication --save
+npm install @feathersjs/authentication --save
 ```
 
 The `JWTStrategy` is an [authentication strategy](./strategy.md) included in `@feathersjs/authentication` for authenticating JSON web token service methods calls and HTTP requests, e.g.

--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/authentication-local/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/authentication-local --save
+npm install @feathersjs/authentication-local --save
 ```
 
 `@feathersjs/authentication-local` provides a `LocalStrategy` for authenticating with a username/email and password combination, e.g.

--- a/api/authentication/oauth.md
+++ b/api/authentication/oauth.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/authentication-oauth/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/authentication-oauth --save
+npm install @feathersjs/authentication-oauth --save
 ```
 
 `@feathersjs/authentication-oauth` allows to authenticate with over 180 oAuth providers (Google, Facebook, GitHub etc.) using [grant](https://github.com/simov/grant), an oAuth middleware module for NodeJS.

--- a/api/authentication/service.md
+++ b/api/authentication/service.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/authentication/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/authentication --save
+npm install @feathersjs/authentication --save
 ```
 
 The `AuthenticationService` is a [Feathers service](../services.md) that allows to register different [authentication strategies](./strategy.md) and manage access tokens (using [JSON web tokens (JWT)](https://jwt.io/) by default). This section describes

--- a/api/client.md
+++ b/api/client.md
@@ -53,7 +53,7 @@ messageService.create({
 React Native usage is the same as for the [Node client](#node). Install the required packages into your [React Native](https://facebook.github.io/react-native/) project.
 
 ```bash
-$ npm install @feathersjs/feathers @feathersjs/socketio-client socket.io-client
+npm install @feathersjs/feathers @feathersjs/socketio-client socket.io-client
 ```
 
 Then in the main application file:
@@ -137,7 +137,7 @@ As mentioned above, `node_modules/@feathersjs` and all its subfolders must be in
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/client/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/client --save
+npm install @feathersjs/client --save
 ```
 
 `@feathersjs/client` is a module that bundles the separate Feathers client-side modules into one providing the code as ES5 which is compatible with modern browsers (IE10+). It can also be used directly in the browser through a `<script>` tag. Here is a table of which Feathers client module is included:

--- a/api/client/primus.md
+++ b/api/client/primus.md
@@ -34,7 +34,7 @@ const socket = new Socket('http://api.feathersjs.com');
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/primus-client/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/primus-client --save
+npm install @feathersjs/primus-client --save
 ```
 
 The `@feathersjs/primus-client` module allows to connect to services exposed through the [Primus server](../primus.md) via the configured websocket library.

--- a/api/client/rest.md
+++ b/api/client/rest.md
@@ -6,7 +6,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/rest-client/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/rest-client --save
+npm install @feathersjs/rest-client --save
 ```
 
 `@feathersjs/rest-client` allows to connect to a service exposed through the [Express REST API](../express.md#expressrest) using [jQuery](https://jquery.com/), [request](https://github.com/request/request), [Superagent](http://visionmedia.github.io/superagent/), [Axios](https://github.com/mzabriskie/axios) or [Fetch](https://facebook.github.io/react-native/docs/network.html) as the AJAX library.

--- a/api/client/socketio.md
+++ b/api/client/socketio.md
@@ -6,7 +6,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/socketio-client/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/socketio-client --save
+npm install @feathersjs/socketio-client --save
 ```
 
 The `@feathersjs/socketio-client` module allows to connect to services exposed through the [Socket.io transport](../socketio.md) via a Socket.io socket.

--- a/api/configuration.md
+++ b/api/configuration.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/configuration/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/configuration --save
+npm install @feathersjs/configuration --save
 ```
 
 `@feathersjs/configuration` is a wrapper for [node-config](https://github.com/lorenwest/node-config) which allows to configure a server side Feathers application.
@@ -115,7 +115,7 @@ Or via custom environment variables by setting them in `config/custom-environmen
 ```
 
 ```
-$ PORT=8080 MONGOHQ_URL=mongodb://localhost:27017/production NODE_ENV=production node app
+PORT=8080 MONGOHQ_URL=mongodb://localhost:27017/production NODE_ENV=production node app
 // -> path/to/app/public/dist
 // -> myapp.com
 // -> 8080

--- a/api/errors.md
+++ b/api/errors.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/errors/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/errors --save
+npm install @feathersjs/errors --save
 ```
 
 The `@feathersjs/errors` module contains a set of standard error classes used by all other Feathers modules.

--- a/api/express.md
+++ b/api/express.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/express/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/express --save
+npm install @feathersjs/express --save
 ```
 
 The `@feathersjs/express` module contains [Express](http://expressjs.com/) framework integrations for Feathers:

--- a/api/primus.md
+++ b/api/primus.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/primus/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/primus --save
+npm install @feathersjs/primus --save
 ```
 
 The [@feathersjs/primus](https://github.com/feathersjs/primus) module allows to call [service methods](./services.md) and receive [real-time events](./events.md) via [Primus](https://github.com/primus/primus), a universal wrapper for real-time frameworks that supports Engine.IO, WebSockets, Faye, BrowserChannel, SockJS and Socket.IO.
@@ -16,7 +16,7 @@ The [@feathersjs/primus](https://github.com/feathersjs/primus) module allows to 
 Additionally to `@feathersjs/primus` your websocket library of choice also has to be installed.
 
 ```
-$ npm install ws --save
+npm install ws --save
 ```
 
 ### app.configure(primus(options))

--- a/api/socketio.md
+++ b/api/socketio.md
@@ -4,7 +4,7 @@
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/master/packages/socketio/CHANGELOG.md)
 
 ```
-$ npm install @feathersjs/socketio --save
+npm install @feathersjs/socketio --save
 ```
 
 The [@feathersjs/socketio](https://github.com/feathersjs/socketio) module allows to call [service methods](./services.md) and receive [real-time events](./events.md) via [Socket.io](http://socket.io/), a NodeJS library which enables real-time bi-directional, event-based communication.

--- a/cookbook/deploy/docker.md
+++ b/cookbook/deploy/docker.md
@@ -5,9 +5,9 @@ A Feathers application can be [dockerized like any other Node.js application](ht
 ## Create an app
 
 ```sh
-$ mkdir feathers-app
-$ cd feathers-app/
-$ feathers generate app
+mkdir feathers-app
+cd feathers-app/
+feathers generate app
 ```
 
 ### Dockerfile
@@ -33,11 +33,11 @@ CMD ["npm", "run", "start"]
 ## Build the image
 
 ```sh
-$ docker build -t my-feathers-image .
+docker build -t my-feathers-image .
 ```
 
 ## Start the container
 
 ```sh
-$ docker run -d -p 3030:3030 --name my-feathers-container my-feathers-image 
+docker run -d -p 3030:3030 --name my-feathers-container my-feathers-image
 ```

--- a/guides/basics/generator.md
+++ b/guides/basics/generator.md
@@ -13,9 +13,9 @@ npm install @feathersjs/cli -g
 Let's create a new directory for our app and in it, generate a new application:
 
 ```sh
-$ mkdir feathers-chat
-$ cd feathers-chat/
-$ feathers generate app
+mkdir feathers-chat
+cd feathers-chat/
+feathers generate app
 ```
 
 First, choose if you want to use JavaScript or TypeScript. When presented with the project name, just hit enter, or enter a name (no spaces). Next, write a short description of your application. All other questions should be confirmed with the default selection by hitting Enter.


### PR DESCRIPTION
This make the copy/paste feature easy to use.

Indeed, if you currently use the copy/paste button, the prompt is also copied, leading to this kind of error:

```
❯ $ npm install @feathersjs/feathers @feathersjs/socketio-client socket.io-client

zsh: command not found: $
```

It not very convenient having to remove this prompt on each command copy.