### PR TITLE
Updated configuration docs for nested properties

### DIFF
--- a/api/configuration.md
+++ b/api/configuration.md
@@ -26,6 +26,8 @@ const configuration = require('@feathersjs/configuration');
 const app = feathers().configure(configuration())
 ```
 
+**Note**: Direct access to nested config properties is not supported via `app.get()`. To access a nested config property (e.g. `Customer.dbConfig.host`, use `app.get('Customer').dbConfig.host` or `require('config')` directly and use it [as documented](https://github.com/lorenwest/node-config). 
+
 ## Variable types
 
 `@feathersjs/configuration` uses the following variable mechanisms:


### PR DESCRIPTION
Added important detail that when using @feathers/configuration,  app.get() can't directly access nested properties. 
https://github.com/feathersjs-ecosystem/configuration/issues/38


I stumbled upon this unexpected behavior and spent some time debugging the issue. Having worked with node-config for some time I just expected nested properties to work just as well with `app.get()`/`app.set()` as with `config.get()`/`config.set()`.