### PR TITLE
fix: use consistent reference to OAuth

### DIFF
--- a/api/authentication/client.md
+++ b/api/authentication/client.md
@@ -13,8 +13,8 @@ The `@feathersjs/authentication-client` module allows you to easily authenticate
 
 - `storage` (default: `localStorage` if available, `MemoryStorage` otherwise) - The storage to store the access token. For React Native use [async-storage](https://github.com/react-native-community/async-storage).
 - `path` (default: '/authentication') - The path of the authentication service
-- `locationKey` (default: `'access_token'`) - The name of the window hash parameter to parse for an access token from the `window.location`. Usually used by the oAuth flow.
-- `locationErrorKey` (default: `'error') - The name of the window hash parameter to parse for authentication errors. Usually used by the oAuth flow.
+- `locationKey` (default: `'access_token'`) - The name of the window hash parameter to parse for an access token from the `window.location`. Usually used by the OAuth flow.
+- `locationErrorKey` (default: `'error') - The name of the window hash parameter to parse for authentication errors. Usually used by the OAuth flow.
 - `jwtStrategy` (default: `'jwt'`) - The access token authentication strategy
 - `storageKey` (default: `'feathers-jwt'`) - Key for storing the token in e.g. localStorage
 - `header` (default: `'Authorization'`) - Name of the accessToken header
@@ -45,7 +45,7 @@ app.configure(auth({
 
 ## app.reAuthenticate()
 
-`app.reAuthenticate() -> Promise` will try to authenticate using the access token from the storage or the window location (e.g. after a successful [oAuth](./oauth.md) login). This is normally called to either show your application (when successful) or showing a login page or redirecting to the appropriate oAuth link.
+`app.reAuthenticate() -> Promise` will try to authenticate using the access token from the storage or the window location (e.g. after a successful [OAuth](./oauth.md) login). This is normally called to either show your application (when successful) or showing a login page or redirecting to the appropriate OAuth link.
 
 ```js
 app.reAuthenticate().then(() => {
@@ -115,7 +115,7 @@ Returns the instance of the [AuthenticationClient](#authenticationclient).
 
 ### getFromLocation(location)
 
-`app.authentication.getFromLocation(location) -> Promise` tries to retrieve an access token from `window.location`. This usually means the `access_token` in the hash set by the [oAuth authentication strategy](./oauth.md).
+`app.authentication.getFromLocation(location) -> Promise` tries to retrieve an access token from `window.location`. This usually means the `access_token` in the hash set by the [OAuth authentication strategy](./oauth.md).
 
 ### setAccessToken(token)
 

--- a/api/authentication/oauth.md
+++ b/api/authentication/oauth.md
@@ -7,7 +7,7 @@
 npm install @feathersjs/authentication-oauth --save
 ```
 
-`@feathersjs/authentication-oauth` allows to authenticate with over 180 oAuth providers (Google, Facebook, GitHub etc.) using [grant](https://github.com/simov/grant), an oAuth middleware module for NodeJS.
+`@feathersjs/authentication-oauth` allows to authenticate with over 180 OAuth providers (Google, Facebook, GitHub etc.) using [grant](https://github.com/simov/grant), an OAuth middleware module for NodeJS.
 
 ## Configuration
 
@@ -15,7 +15,7 @@ The following settings are available:
 
 - `redirect`: The URL of the frontend to redirect to with the access token (or error message). The [authentication client](./client.md) handles those redirects automatically. If not set, the authentication result will be sent as JSON instead.
 - `defaults`: Default [Grant configuration](https://github.com/simov/grant#configuration) used for all strategies. The following default options are set automatically:
-  - `path` (default: `'/oauth'`) - The oAuth base path
+  - `path` (default: `'/oauth'`) - The OAuth base path
 - `<strategy-name>` (e.g. `twitter`): The [Grant configuration](https://github.com/simov/grant#configuration) used for a specific strategy.
 - For both `defaults` and specific strategies, the following options are set automatically:
   - `host`: Set to `host` from the configuration
@@ -23,9 +23,9 @@ The following settings are available:
   - `transport`: Set to `'session'` (see [Grant response data](https://github.com/simov/grant#response-data-transport))
   - `callback`: Set to `'<defaults.path>/<name>/authenticate'`. This should not be changed.
 
-> __Pro tip:__ Removing the `redirect` setting is a good way to troubleshoot oAuth authentication errors.
+> __Pro tip:__ Removing the `redirect` setting is a good way to troubleshoot OAuth authentication errors.
 
-Standard oAuth authentication can be configured with those options in `config/default.json` like this:
+Standard OAuth authentication can be configured with those options in `config/default.json` like this:
 
 ```json
 {
@@ -46,7 +46,7 @@ Standard oAuth authentication can be configured with those options in `config/de
 }
 ```
 
-> __Note:__ All oAuth strategies will by default always look for configuration under `authentication.oauth.<name>`. If `authentication.oauth` is not set in the configuration, oAuth authentication will be disabled.
+> __Note:__ All OAuth strategies will by default always look for configuration under `authentication.oauth.<name>`. If `authentication.oauth` is not set in the configuration, OAuth authentication will be disabled.
 
 Here is a [list of all Grant configuration options](https://github.com/simov/grant#all-available-options) that are available:
 
@@ -80,7 +80,7 @@ redirect_uri | generated | OAuth app [redirect URI](#redirect-uri), generated us
 
 ### Cookbook guides
 
-For specific oAuth provider setup see the following [cookbook](../../cookbook/) guides:
+For specific OAuth provider setup see the following [cookbook](../../cookbook/) guides:
 
 - [Auth0](../../cookbook/authentication/auth0.md)
 - [Facebook](../../cookbook/authentication/facebook.md)
@@ -88,10 +88,10 @@ For specific oAuth provider setup see the following [cookbook](../../cookbook/) 
 
 ### Flow
 
-There are two ways to initiate oAuth authentication:
+There are two ways to initiate OAuth authentication:
 
 1) Through the browser (most common)
-    - User clicks on link to oAuth URL (`oauth/<provider>`)
+    - User clicks on link to OAuth URL (`oauth/<provider>`)
     - Gets redirected to provider and authorizes the application
     - Callback to the [OauthStrategy](#oauthstrategy) which
         - Gets the users profile
@@ -109,15 +109,15 @@ There are two ways to initiate oAuth authentication:
 
 > __Note:__ If you are attempting to authenticate using an obtained access token, ensure that you have added the strategy (e.g. 'facebook') to your [authStrategies](./service.md#configuration).
 
-### oAuth URLs
+### OAuth URLs
 
-There are several URLs and redirects that are important for oAuth authentication:
+There are several URLs and redirects that are important for OAuth authentication:
 
-- `http(s)://<host>/oauth/<provider>`: The main URL to initiate the oAuth flow. Link to this from the browser.
-- `http(s)://<host>/oauth/<provider>/callback`: The callback path that should be set in the oAuth application settings
+- `http(s)://<host>/oauth/<provider>`: The main URL to initiate the OAuth flow. Link to this from the browser.
+- `http(s)://<host>/oauth/<provider>/callback`: The callback path that should be set in the OAuth application settings
 - `http(s)://<host>/oauth/<provider>/authenticate`: The internal redirect
 
-In the browser any oAuth flow can be initiated with the following link:
+In the browser any OAuth flow can be initiated with the following link:
 
 ```html
 <a href="/oauth/github">Login with GitHub</a>
@@ -125,7 +125,7 @@ In the browser any oAuth flow can be initiated with the following link:
 
 ### Account linking
 
-To _link an existing user_ the current access token can be added to the oAuth flow query using the `feathers_token` query parameter:
+To _link an existing user_ the current access token can be added to the OAuth flow query using the `feathers_token` query parameter:
 
 ```html
 <a href="/oauth/github?feathers_token=<your access token>">
@@ -133,7 +133,7 @@ To _link an existing user_ the current access token can be added to the oAuth fl
 </a>
 ```
 
-This will use the user (entity) of that access token to link the oAuth account to. Using the [authentication client](./client.md) you can get the current access token via `app.get('authentication')`:
+This will use the user (entity) of that access token to link the OAuth account to. Using the [authentication client](./client.md) you can get the current access token via `app.get('authentication')`:
 
 ```js
 const { accessToken } = await app.get('authentication');
@@ -141,7 +141,7 @@ const { accessToken } = await app.get('authentication');
 
 ### Redirects
 
-The `redirect` configuration option is used to redirect back to the frontend application after oAuth authentication was successful and an access token for the user has been created by the [authentication service](./service.md) or if authentication failed. It works cross domain and by default includes the access token or error message in the window location hash. The following configuration
+The `redirect` configuration option is used to redirect back to the frontend application after OAuth authentication was successful and an access token for the user has been created by the [authentication service](./service.md) or if authentication failed. It works cross domain and by default includes the access token or error message in the window location hash. The following configuration
 
 ```js
 {
@@ -153,13 +153,13 @@ The `redirect` configuration option is used to redirect back to the frontend app
 }
 ```
 
-Will redirect to `https://app.mydomain.com/#access_token=<user jwt>` or `https://app.mydomain.com/#error=<some error message>`. Redirects can be customized with the [getRedirect()](#getredirect-data) method of the oAuth strategy. The [authentication client](./client.md) handles the default redirects automatically already.
+Will redirect to `https://app.mydomain.com/#access_token=<user jwt>` or `https://app.mydomain.com/#error=<some error message>`. Redirects can be customized with the [getRedirect()](#getredirect-data) method of the OAuth strategy. The [authentication client](./client.md) handles the default redirects automatically already.
 
 > __Note:__ The redirect is using a hash instead of a query string by default because it is not logged server side and can be easily read on the client. You can force query based redirect by adding a `?` to the end of the `redirect` option.
 
 If the `redirect` option is not set, the authentication result data will be sent as JSON instead.
 
-Dynamic redirects to the same URL are possible by setting the `redirect` query parameter in the oAuth flow. For example, the following oAuth link:
+Dynamic redirects to the same URL are possible by setting the `redirect` query parameter in the OAuth flow. For example, the following OAuth link:
 
 ```html
 <a href="/oauth/github?redirect=dashboard">
@@ -167,11 +167,11 @@ Dynamic redirects to the same URL are possible by setting the `redirect` query p
 </a>
 ```
 
-With the above configuration will redirect to `https://app.mydomain.com/dashboard` after the oAuth flow.
+With the above configuration will redirect to `https://app.mydomain.com/dashboard` after the OAuth flow.
 
 ## Setup (Express)
 
-`expressOauth` (for setup see the [AuthenticationService](./service.md)) sets up oAuth authentication on a [Feathers Express](../express.md) application and can take the following options:
+`expressOauth` (for setup see the [AuthenticationService](./service.md)) sets up OAuth authentication on a [Feathers Express](../express.md) application and can take the following options:
 
 - `authService`: The name of the authentication service
 - `linkStrategy` (default: `'jwt'`): The name of the strategy to use for account linking
@@ -194,7 +194,7 @@ app.configure(expressOauth({
 }));
 ```
 
-> __Important:__  If not customized, Express oAuth uses the in-memory Express session store which will show a `connect.session() MemoryStore is not designed for a production environment, as it will leak memory, and will not scale past a single process.` warning in production.
+> __Important:__  If not customized, Express OAuth uses the in-memory Express session store which will show a `connect.session() MemoryStore is not designed for a production environment, as it will leak memory, and will not scale past a single process.` warning in production.
 
 ## OAuthStrategy
 
@@ -218,11 +218,11 @@ app.configure(expressOauth({
 
 ### getProfile(data, params)
 
-`oauthStrategy.getProfile(data, params) -> Promise` returns the user profile information from the oAuth provider that was used for the login. `data` is the oAuth callback information which normally contains e.g. the oAuth access token.
+`oauthStrategy.getProfile(data, params) -> Promise` returns the user profile information from the OAuth provider that was used for the login. `data` is the OAuth callback information which normally contains e.g. the OAuth access token.
 
 ### getRedirect (data)
 
-`oauthStrategy.getRedirect(data) -> Promise` returns the URL to redirect to after a successful oAuth login and entity lookup or creation. By default it redirects to `authentication.oauth.redirect` from the configuration with `#access_token=<access token for entity>` added to the end of the URL. The `access_token` hash is e.g. used by the [authentication client](./client.md) to log the user in after a successful oAuth login. The default redirects do work cross domain.
+`oauthStrategy.getRedirect(data) -> Promise` returns the URL to redirect to after a successful OAuth login and entity lookup or creation. By default it redirects to `authentication.oauth.redirect` from the configuration with `#access_token=<access token for entity>` added to the end of the URL. The `access_token` hash is e.g. used by the [authentication client](./client.md) to log the user in after a successful OAuth login. The default redirects do work cross domain.
 
 ### getCurrentEntity(params)
 
@@ -230,11 +230,11 @@ app.configure(expressOauth({
 
 ### findEntity(profile, params)
 
-`oauthStrategy.findEntity(profile, params) -> Promise` finds an entity for a given oAuth profile. Uses `{ [${this.name}Id]: profile.id }` by default.
+`oauthStrategy.findEntity(profile, params) -> Promise` finds an entity for a given OAuth profile. Uses `{ [${this.name}Id]: profile.id }` by default.
 
 ### createEntity(profile, params)
 
-`oauthStrategy.createEntity(profile, params) -> Promise` creates a new entity for the given oAuth profile. Uses `{ [${this.name}Id]: profile.id }` by default.
+`oauthStrategy.createEntity(profile, params) -> Promise` creates a new entity for the given OAuth profile. Uses `{ [${this.name}Id]: profile.id }` by default.
 
 ### updateEntity(entity, profile, params)
 
@@ -246,7 +246,7 @@ app.configure(expressOauth({
 
 ## Customization
 
-Normally, any oAuth provider set up in the [configuration](#configuration) will be initialized with the default [OAuthStrategy](#oauthstrategy). The flow for a specific provider can be customized by extending `OAuthStrategy` class and registering it under that name on the [AuthenticationService](./service.md):
+Normally, any OAuth provider set up in the [configuration](#configuration) will be initialized with the default [OAuthStrategy](#oauthstrategy). The flow for a specific provider can be customized by extending `OAuthStrategy` class and registering it under that name on the [AuthenticationService](./service.md):
 
 :::: tabs :options="{ useUrlFragment: false }"
 

--- a/api/authentication/readme.md
+++ b/api/authentication/readme.md
@@ -1,6 +1,6 @@
 # Overview
 
-The `@feathersjs/authentication` plugins provide a collection of tools for managing username/password, JWT and oAuth (GitHub, Facebook etc.) authentication as well as custom authentication mechanisms and for authenticating on the client.
+The `@feathersjs/authentication` plugins provide a collection of tools for managing username/password, JWT and OAuth (GitHub, Facebook etc.) authentication as well as custom authentication mechanisms and for authenticating on the client.
 
 It consists of the following core modules:
 
@@ -9,7 +9,7 @@ It consists of the following core modules:
   - The [JWTStrategy](./jwt.md) to use JWTs to make authenticated requests
   - The [authenticate hook](./hook.md) to limit service calls to an authentication strategy.
 - [Local authentication](./local.md) for local username/password authentication
-- [oAuth authentication](./oauth.md) for GitHub, Facebook etc. authentication
+- [OAuth authentication](./oauth.md) for GitHub, Facebook etc. authentication
 - [The authentication client](./client.md) to use Feathers authentication on the client.
 
 > *Important:* `@feathersjs/authentication` is an abstraction for different authentication mechanisms. It does not handle things like user verification or password reset functionality etc. This can be implemented manually, with the help of libraries like [feathers-authentication-management](https://github.com/feathers-plus/feathers-authentication-management) or a platform like [Auth0](https://auth0.com/).

--- a/api/authentication/service.md
+++ b/api/authentication/service.md
@@ -18,7 +18,7 @@ The `AuthenticationService` is a [Feathers service](../services.md) that allows 
 
 ## Setup
 
-The standard setup of [the generator]() initializes an [AuthenticationService](#authenticationservice) at the `/authentication` path with a [JWT strategy](./jwt.md), [Local strategy](./local.md) and [oAuth authentication](./oauth.md).
+The standard setup of [the generator]() initializes an [AuthenticationService](#authenticationservice) at the `/authentication` path with a [JWT strategy](./jwt.md), [Local strategy](./local.md) and [OAuth authentication](./oauth.md).
 
 :::: tabs :options="{ useUrlFragment: false }"
 

--- a/api/readme.md
+++ b/api/readme.md
@@ -46,7 +46,7 @@ Feathers authentication mechanism
 * [Strategies](authentication/strategy.md) - More about authentication strategies
 * [Local](authentication/local.md) - Local email/password authentication
 * [JWT](authentication/jwt.md) - JWT authentication
-* [OAuth](authentication/oauth.md) - Using oAuth logins (Facebook, Twitter etc.)
+* [OAuth](authentication/oauth.md) - Using OAuth logins (Facebook, Twitter etc.)
 * [Client](authentication/client.md) - A client for a Feathers authentication server
 
 ## Databases

--- a/cookbook/authentication/_discord.md
+++ b/cookbook/authentication/_discord.md
@@ -1,6 +1,6 @@
 # Discord
 
-Discord login can be initialized like any other [oAuth provider](../../api/authentication/oauth.md) by adding the app id and secret to `config/default.json`:
+Discord login can be initialized like any other [OAuth provider](../../api/authentication/oauth.md) by adding the app id and secret to `config/default.json`:
 
 ```js
 {
@@ -49,7 +49,7 @@ export default function (app: Application) {
 
 export default class DiscordStrategy extends OAuthStrategy {
   async getProfile(authResult: AuthenticationRequest) {
-    // This is the oAuth access token that can be used
+    // This is the OAuth access token that can be used
     // for Discord API requests as the Bearer token
     const accessToken = authResult.access_token;
     const userOptions: AxiosRequestConfig = {

--- a/cookbook/authentication/auth0.md
+++ b/cookbook/authentication/auth0.md
@@ -1,6 +1,6 @@
 # Auth0
 
-To enable oAuth logins with [Auth0](http://auth0.com), we need the following settings after creating an application:
+To enable OAuth logins with [Auth0](http://auth0.com), we need the following settings after creating an application:
 
 ![Auth0 application](../assets/auth0-app.png)
 

--- a/cookbook/authentication/facebook.md
+++ b/cookbook/authentication/facebook.md
@@ -1,6 +1,6 @@
 # Facebook
 
-Facebook login can be initialized like any other [oAuth provider](../../api/authentication/oauth.md) by adding the app id and secret to `config/default.json`:
+Facebook login can be initialized like any other [OAuth provider](../../api/authentication/oauth.md) by adding the app id and secret to `config/default.json`:
 
 ```js
 {
@@ -38,7 +38,7 @@ The client id (App ID) and secret can be found in the Settings of the [Facebook 
 
 ## Getting profile data
 
-The standard oAuth strategy only returns the default profile fields (`id` and `name`). To get other fields, like the email or profile picture, the [getProfile](../../api/authentication/oauth.md#getprofile-data-params) method of the [oAuth strategy needs to be customized](../../api/authentication/oauth.md#customization) to call the Graph API profile endpoint `https://graph.facebook.com/me` with an HTTP request library like [Axios](https://developers.facebook.com/tools/explorer/) requesting the additional fields.
+The standard OAuth strategy only returns the default profile fields (`id` and `name`). To get other fields, like the email or profile picture, the [getProfile](../../api/authentication/oauth.md#getprofile-data-params) method of the [OAuth strategy needs to be customized](../../api/authentication/oauth.md#customization) to call the Graph API profile endpoint `https://graph.facebook.com/me` with an HTTP request library like [Axios](https://developers.facebook.com/tools/explorer/) requesting the additional fields.
 
 > __Pro tip:__ Facebook API requests can be tested via the [Graph API explorer](https://developers.facebook.com/tools/explorer/).
 
@@ -56,7 +56,7 @@ const { expressOauth, OAuthStrategy } = require('@feathersjs/authentication-oaut
 
 class FacebookStrategy extends OAuthStrategy {
   async getProfile (authResult) {
-    // This is the oAuth access token that can be used
+    // This is the OAuth access token that can be used
     // for Facebook API requests as the Bearer token
     const accessToken = authResult.access_token;
 
@@ -114,7 +114,7 @@ declare module './declarations' {
 
 class FacebookStrategy extends OAuthStrategy {
   async getProfile (authResult: AuthenticationRequest, _params: Params) {
-    // This is the oAuth access token that can be used
+    // This is the OAuth access token that can be used
     // for Facebook API requests as the Bearer token
     const accessToken = authResult.access_token;
 

--- a/guides/basics/authentication.md
+++ b/guides/basics/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-We now have a fully functional chat application consisting of [services](./services.md) and [hooks](./hooks.md). The services come with authentication enabled by default, so before we can use it we need to create a new user and learn how Feathers authentication works. We will look at authenticating our REST API, and then how to authenticate with Feathers in the browser. Finally, we will discuss how to add "Login with GitHub" functionality using oAuth 2.0.
+We now have a fully functional chat application consisting of [services](./services.md) and [hooks](./hooks.md). The services come with authentication enabled by default, so before we can use it we need to create a new user and learn how Feathers authentication works. We will look at authenticating our REST API, and then how to authenticate with Feathers in the browser. Finally, we will discuss how to add "Login with GitHub" functionality using OAuth 2.0.
 
 ## Registering a user
 
@@ -158,11 +158,11 @@ main();
 
 If you now open the console and visit [localhost:3030](http://localhost:3030) you will see that our user has been authenticated.
 
-## GitHub login (oAuth)
+## GitHub login (OAuth)
 
-oAuth is an open authentication standard supported by almost every major platform. It is what is being used by the login with Facebook, Google, GitHub etc. buttons in a web application. From the Feathers perspective the authentication flow is pretty similar. Instead of authenticating with the `local` strategy by sending a username and password, we direct the user to authorize the application with the login provider. If it is successful we find or create the user on the `users` service with the information we got back from the provider and issue a token for them.
+OAuth is an open authentication standard supported by almost every major platform. It is what is being used by the login with Facebook, Google, GitHub etc. buttons in a web application. From the Feathers perspective the authentication flow is pretty similar. Instead of authenticating with the `local` strategy by sending a username and password, we direct the user to authorize the application with the login provider. If it is successful we find or create the user on the `users` service with the information we got back from the provider and issue a token for them.
 
-Let's use GitHub as an example for how to set up a "Login with GitHub" button. First, we have to [create a new oAuth application on GitHub](https://github.com/settings/applications/new). You can put anything in the name, homepage and description fields. The callback URL __must__ be set
+Let's use GitHub as an example for how to set up a "Login with GitHub" button. First, we have to [create a new OAuth application on GitHub](https://github.com/settings/applications/new). You can put anything in the name, homepage and description fields. The callback URL __must__ be set
 
 ```sh
 http://localhost:3030/oauth/github/callback
@@ -170,7 +170,7 @@ http://localhost:3030/oauth/github/callback
 
 ![Screenshot of the GitHub application screen](./assets/github-app.png)
 
-> __Note:__ You can find your existing applications in the [GitHub oAuth apps developer settings](https://github.com/settings/developers).
+> __Note:__ You can find your existing applications in the [GitHub OAuth apps developer settings](https://github.com/settings/developers).
 
 Once you clicked "Register application" we have to update our Feathers app configuration with the client id and secret copied from the GitHub application settings:
 
@@ -194,7 +194,7 @@ Find the `authentication` section in `config/default.json` add a configuration s
 }
 ```
 
-This tells the oAuth strategy to redirect back to our index page after a successful login and already makes a basic login with GitHub possible. Because of the changes we made in the `users` service in the [services chapter](./services.md) we do need a small customization though. Instead of only adding `githubId` to a new user when they log in with GitHub we also include their email (if it is available), the display name to show in the chat and the avatar image from the profile we get back. We can do this by extending the standard oAuth strategy and registering it as a GitHub specific one and overwriting the `getEntityData` method:
+This tells the OAuth strategy to redirect back to our index page after a successful login and already makes a basic login with GitHub possible. Because of the changes we made in the `users` service in the [services chapter](./services.md) we do need a small customization though. Instead of only adding `githubId` to a new user when they log in with GitHub we also include their email (if it is available), the display name to show in the chat and the avatar image from the profile we get back. We can do this by extending the standard OAuth strategy and registering it as a GitHub specific one and overwriting the `getEntityData` method:
 
 :::: tabs :options="{ useUrlFragment: false }"
 ::: tab "JavaScript"
@@ -280,11 +280,11 @@ export default function(app: Application) {
 :::
 ::::
 
-> __Pro tip:__ For more information about the oAuth flow and strategy see the [oAuth API documentation](../../api/authentication/oauth.md).
+> __Pro tip:__ For more information about the OAuth flow and strategy see the [OAuth API documentation](../../api/authentication/oauth.md).
 
-When we set up the [authentication client in the browser](#browser-authentication) it can also already handle oAuth logins. To log in with GitHub, visit [localhost:3030/oauth/github](http://localhost:3030/oauth/github). It will redirect to GitHub and ask to authorize our application. If everything went well, you will see a user with your GitHub email address being logged in the console.
+When we set up the [authentication client in the browser](#browser-authentication) it can also already handle OAuth logins. To log in with GitHub, visit [localhost:3030/oauth/github](http://localhost:3030/oauth/github). It will redirect to GitHub and ask to authorize our application. If everything went well, you will see a user with your GitHub email address being logged in the console.
 
-> __Note:__ The authentication client will not use the token from the oAuth login if there is already another token logged in. See the [oAuth API](../../api/authentication/oauth.md) for how to link to an existing account.
+> __Note:__ The authentication client will not use the token from the OAuth login if there is already another token logged in. See the [OAuth API](../../api/authentication/oauth.md) for how to link to an existing account.
 
 ## What's next?
 

--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -23,7 +23,7 @@ This will update the dependencies in `package.json`, update the `src/authenticat
 __Manual steps are necessary for__
 
 - The `hashPassword()` hook in `service/users/users.hooks.js` which now requires the password field name (usually `hashPassword('password')`)
-- Configuring oAuth providers - see [oAuth API](../api/authentication/oauth.md)
+- Configuring OAuth providers - see [OAuth API](../api/authentication/oauth.md)
 - The authentication Express middleware has been moved to `const { authenticate } = require('@feathersjs/express');`
 - Any other authentication specific customization - see [authentication service API](../api/authentication/service.md)
 - Feathers client authentication - see [authentication client API](../api/authentication/client.md)
@@ -34,8 +34,8 @@ The `@feathersjs/authentication-*` modules have been completely rewritten to inc
 
 - An extensible [authentication service](../api/authentication/service.md) that can register strategies and create authentication tokens (JWT by default but pluggable for anything else)
 - Protocol independent, fully customizable authentication strategies
-- Better [oAuth authentication](../api/authentication/oauth.md) with 180+ providers supported out of the box without any additional configuration (other than adding the application key and secret)
-- Built-in oAuth account linking and cross-domain oAuth redirects
+- Better [OAuth authentication](../api/authentication/oauth.md) with 180+ providers supported out of the box without any additional configuration (other than adding the application key and secret)
+- Built-in OAuth account linking and cross-domain OAuth redirects
 
 ### Manual upgrade
 
@@ -84,7 +84,7 @@ export default (app: Application) => {
 
 > __Important:__ The `@feathersjs/authentication-jwt` is deprecated since the JWT strategy is now directly included in `@feathersjs/authentication`.
 
-This will register `local`, `jwt` and oAuth authentication strategies using the standard authentication service on the `/authentication` path. oAuth will only be active if provider information is added to the configuration. The authentication configuration (usually in `config/default.json`) should be updated as follows:
+This will register `local`, `jwt` and OAuth authentication strategies using the standard authentication service on the `/authentication` path. OAuth will only be active if provider information is added to the configuration. The authentication configuration (usually in `config/default.json`) should be updated as follows:
 
 ```json
 "authentication": {
@@ -370,11 +370,11 @@ module.exports = app => {
 };
 ```
 
-### oAuth cookies
+### OAuth cookies
 
-To support oAuth for the old authentication client that was using a cookie instead of the redirect to transmit the access token the following middleware can be used:
+To support OAuth for the old authentication client that was using a cookie instead of the redirect to transmit the access token the following middleware can be used:
 
-> __Note:__ This is only necessary if the Feathers authentication client is not updated at the same time and if oAuth is being used.
+> __Note:__ This is only necessary if the Feathers authentication client is not updated at the same time and if OAuth is being used.
 
 ```js
 const authService = new AuthenticationService(app);


### PR DESCRIPTION
There are several instances of the docs referencing both `oAuth` and `OAuth`.

This PR changes all references to `OAuth`: https://en.wikipedia.org/wiki/OAuth