### PR TITLE
docs: add hook-less service method description

### DIFF
--- a/api/databases/common.md
+++ b/api/databases/common.md
@@ -179,6 +179,18 @@ This section describes specifics on how the [service methods](../services.md) ar
 
 Initializes a new service. Should call `super(options)` when overwritten.
 
+### hook-less
+
+The database adapters now support calling their service methods without any hooks by adding a `_` in front of the method name as `_find`, `_get`, `_create`, `_patch`, `_update` and `_remove`. This can be useful if you need the raw data from the service and don't want to trigger any of its hooks.
+
+```js
+// Call `get` without running any hooks
+const message = await app.service('/messages')._get('<message id>');
+```
+
+> _Note:_ These methods are only available internally on the server, not on the client side and only for the Feathers database adapters. They do *not* send any events.
+
+
 ### adapter.Model
 
 If the ORM or database supports models, the model instance or reference to the collection belonging to this adapter can be found in `adapter.Model`. This allows to easily make custom queries using that model, e.g. in a hook:

--- a/api/databases/common.md
+++ b/api/databases/common.md
@@ -179,9 +179,9 @@ This section describes specifics on how the [service methods](../services.md) ar
 
 Initializes a new service. Should call `super(options)` when overwritten.
 
-### hook-less
+### Methods without hooks
 
-The database adapters now support calling their service methods without any hooks by adding a `_` in front of the method name as `_find`, `_get`, `_create`, `_patch`, `_update` and `_remove`. This can be useful if you need the raw data from the service and don't want to trigger any of its hooks.
+The database adapters support calling their service methods without any hooks by adding a `_` in front of the method name as `_find`, `_get`, `_create`, `_patch`, `_update` and `_remove`. This can be useful if you need the raw data from the service and don't want to trigger any of its hooks.
 
 ```js
 // Call `get` without running any hooks


### PR DESCRIPTION
Currently, the only place learn about hook-less service method is at https://docs.feathersjs.com/guides/migrating.html#hook-less-service-methods and it isn't obvious when looking through the docs..

I have added it to `api/databases/common` at the top after `constructor` but not sure if it should be at the bottom after `adapter.remove(id, params)`. What do you think?

This was brought up by Mike from slack...