### PR TITLE
Bumped up feathers & socketio client version

### DIFF
--- a/api/client.md
+++ b/api/client.md
@@ -194,8 +194,8 @@ Below is an example of the scripts you would use to load `@feathersjs/client` fr
 
 ```html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
-<script src="//unpkg.com/@feathersjs/client@^3.0.0/dist/feathers.js"></script>
-<script src="//unpkg.com/socket.io-client@1.7.3/dist/socket.io.js"></script>
+<script src="//unpkg.com/@feathersjs/client@4.5.7/dist/feathers.js"></script>
+<script src="//unpkg.com/socket.io-client@2.3.0/dist/socket.io.js"></script>
 <script>
   // Socket.io is exposed as the `io` global.
   var socket = io('http://localhost:3030');

--- a/api/client.md
+++ b/api/client.md
@@ -194,8 +194,8 @@ Below is an example of the scripts you would use to load `@feathersjs/client` fr
 
 ```html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
-<script src="//unpkg.com/@feathersjs/client@4.5.7/dist/feathers.js"></script>
-<script src="//unpkg.com/socket.io-client@2.3.0/dist/socket.io.js"></script>
+<script src="//unpkg.com/@feathersjs/client@^4.5.0/dist/feathers.js"></script>
+<script src="//unpkg.com/socket.io-client@^2.3.0/dist/socket.io.js"></script>
 <script>
   // Socket.io is exposed as the `io` global.
   var socket = io('http://localhost:3030');


### PR DESCRIPTION
Bumped up FeathersJS and SocketIO client to the latest version in "Load from CDN with <script>" section.

### Background:
I was experimenting with custom events. I just copied the snippet from the [documentation](https://docs.feathersjs.com/api/client.html#load-from-cdn-with-script). But, when I tried to call `app.reAuthenticate()` it didn't work. Then I noticed that I am importing old version (`3.0.0`) of Feathers client (_the `^` in the URL didn't import the latest one_). So, I changed the version to the latest (`4.5.7`) one and it worked as expected. I've updated the version of socketio as well (`1.7.3` to `2.3.0`).