### PR TITLE
Show in snippets where `authentication` is defined

### DIFF
--- a/cookbook/authentication/anonymous.md
+++ b/cookbook/authentication/anonymous.md
@@ -7,7 +7,7 @@ Anonymous authentication can be allowed by creating a [custom strategy](../../ap
 In `src/authentication.js`:
 
 ```js
-const { AuthenticationBaseStrategy } = require('@feathersjs/authentication');
+const { AuthenticationBaseStrategy, AuthenticationService } = require('@feathersjs/authentication');
 
 class AnonymousStrategy extends AuthenticationBaseStrategy {
   async authenticate(authentication, params) {
@@ -18,6 +18,7 @@ class AnonymousStrategy extends AuthenticationBaseStrategy {
 }
 
 module.exports = app => {
+  const authentication = new AuthenticationService(app);
   // ... authentication service setup
   authentication.register('anonymous', new AnonymousStrategy());
 }
@@ -26,7 +27,7 @@ module.exports = app => {
 ::: tab "TypeScript"
 ```ts
 import { Params } from '@feathersjs/feathers';
-import { AuthenticationBaseStrategy, AuthenticationResult } from '@feathersjs/authentication';
+import { AuthenticationBaseStrategy, AuthenticationResult, AuthenticationService } from '@feathersjs/authentication';
 
 class AnonymousStrategy extends AuthenticationBaseStrategy {
   async authenticate(authentication: AuthenticationResult, params: Params) {
@@ -37,6 +38,7 @@ class AnonymousStrategy extends AuthenticationBaseStrategy {
 }
 
 export default function(app: Application) {
+  const authentication = new AuthenticationService(app);
   // ... authentication service setup
   authentication.register('anonymous', new AnonymousStrategy());
 }


### PR DESCRIPTION
This can be obvious when looking at docs side-by-side with you application's code, but for people just browsing the documentation it can be confusing now knowing where `authentication` was defined, only that there was a likely global object with a `register` method that was used to add an auth strategy.