### PR TITLE
Update Auth0 docs to include a note to save others time

### DIFF
--- a/cookbook/authentication/auth0.md
+++ b/cookbook/authentication/auth0.md
@@ -20,7 +20,7 @@ This should be added in your configuration (usually `config/default.json`) as fo
 }
 ```
 
-> __Important:__ `subdomain` should be the "Domain" from the application settings __without__ the `auth0.com` part. So, in the screenshot above, the subdomain for `dev-6gqkmpt6.auth0.com` would be `dev-6gqkmpt6`. Updates to auth0 if it includes the region, subdomain includes the `.us` so the subdomain for `dev-6gqkmpt6.us.auth0.com` would be `dev-6gqkmpt6.us`
+> __Important:__ `subdomain` should be the "Domain" from the application settings __without__ the `auth0.com` part. So, in the screenshot above, the subdomain for `dev-6gqkmpt6.auth0.com` would be `dev-6gqkmpt6`. If the subdomain includes a region, it needs to be included as well so the subdomain for `dev-6gqkmpt6.us.auth0.com` would be `dev-6gqkmpt6.us`
 
 ## Strategy
 


### PR DESCRIPTION
Referencing https://github.com/feathersjs/feathers/issues/1515

Updates on Auth0 includes a region such as `us` or `uk`, etc...
