### PR TITLE
Dark mode (closes #1378)

### DIFF
--- a/.vuepress/components/Fa/Lightbulb.vue
+++ b/.vuepress/components/Fa/Lightbulb.vue
@@ -1,0 +1,22 @@
+<template><span><font-awesome-icon :icon="theIcon" :pulse="pulse" :border="border" :spin="spin" :pull="pull" :flip="flip" :rotation="rotation" :size="size" :style="attachStyles()"></font-awesome-icon></span></template>
+<script>import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faLightbulb } from "@fortawesome/free-solid-svg-icons";
+library.add(faLightbulb);
+export default {
+   name: "FaLightbulb",
+   components: {FontAwesomeIcon},
+   props:{
+       size: {type: String,required: false,default: null},
+       color: { type: String, required: false, default: null},
+       rotation: { type: [String, Number], required: false, default: null},
+       flip: { type: String, required: false, default: null},
+       pull: { type: String, required: false, default: null},
+       spin: { type: Boolean, required: false, default: false},
+       pulse: { type: Boolean, required: false, default: false},
+       border: { type: Boolean, required: false, default: false},
+   },
+   computed:{ theIcon(){return faLightbulb}},
+   methods: {attachStyles: function(){return this.color ? {color: this.color} : {}}}
+}
+</script>

--- a/.vuepress/components/Fa/ThumbsUp.vue
+++ b/.vuepress/components/Fa/ThumbsUp.vue
@@ -1,0 +1,22 @@
+<template><span><font-awesome-icon :icon="theIcon" :pulse="pulse" :border="border" :spin="spin" :pull="pull" :flip="flip" :rotation="rotation" :size="size" :style="attachStyles()"></font-awesome-icon></span></template>
+<script>import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faThumbsUp } from "@fortawesome/free-solid-svg-icons";
+library.add(faThumbsUp);
+export default {
+   name: "FaThumbsUp",
+   components: {FontAwesomeIcon},
+   props:{
+       size: {type: String,required: false,default: null},
+       color: { type: String, required: false, default: null},
+       rotation: { type: [String, Number], required: false, default: null},
+       flip: { type: String, required: false, default: null},
+       pull: { type: String, required: false, default: null},
+       spin: { type: Boolean, required: false, default: false},
+       pulse: { type: Boolean, required: false, default: false},
+       border: { type: Boolean, required: false, default: false},
+   },
+   computed:{ theIcon(){return faThumbsUp}},
+   methods: {attachStyles: function(){return this.color ? {color: this.color} : {}}}
+}
+</script>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,6 +1,12 @@
 module.exports = {
   title: 'FeathersJS',
   description: 'A REST and real-time API layer for modern applications',
+  thirdPartyComponents: {
+    fontAwesomeIcons:{
+        regular:['lightbulb'],  // Regular font awesome icon keys here
+        solid:[ 'thumbs-up']    // Solid font awesome icon keys here
+    }
+  },
   themeConfig: {
     algolia: {
       apiKey: '2835d290e600f7fb583e2b61a74032ba',

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -26,6 +26,8 @@
       />
       <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false"/>
       <NavLinks class="can-hide"/>
+      <a href="#" style="margin-left:20px" @click="darkMode.toggle()"><span class="tooltip"><Lightbulb alt-text="Toggle dark mode" /><span class="tooltiptext">Toggle dark mode</span></span></a>
+
     </div>
   </header>
 </template>
@@ -35,13 +37,16 @@ import AlgoliaSearchBox from '@AlgoliaSearchBox'
 import SearchBox from '@SearchBox'
 import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
+import Lightbulb from '../../components/Fa/Lightbulb.vue'
+import DarkMode from '../util/dark-mode'
 
 export default {
-  components: { SidebarButton, NavLinks, SearchBox, AlgoliaSearchBox },
+  components: { SidebarButton, NavLinks, SearchBox, AlgoliaSearchBox, Lightbulb },
 
   data () {
     return {
-      linksWrapMaxWidth: null
+      linksWrapMaxWidth: null,
+      darkMode: null
     }
   },
 
@@ -58,6 +63,9 @@ export default {
     }
     handleLinksWrapWidth()
     window.addEventListener('resize', handleLinksWrapWidth, false)
+
+    this.darkMode = new DarkMode()
+    this.darkMode.init()
   },
 
   computed: {
@@ -67,6 +75,13 @@ export default {
 
     isAlgoliaSearch () {
       return this.algolia && this.algolia.apiKey && this.algolia.indexName
+    }
+  },
+
+
+  methods: {
+    toggleDM () {
+      this.darkMode.toggle();
     }
   }
 }

--- a/.vuepress/theme/layouts/Layout.vue
+++ b/.vuepress/theme/layouts/Layout.vue
@@ -147,3 +147,121 @@ export default {
 </script>
 
 <style src="prismjs/themes/prism-tomorrow.css"></style>
+
+<!-- Dark mode : Based on idea from @matiaslopezd, https://github.com/feathersjs/docs/issues/1378 -->
+<style>
+body.dark, body.dark #app, body.dark .navbar, body.dark .sidebar, body.dark .links {
+    background: rgb(13, 22, 28) !important;
+    color: rgb(255, 255, 255);
+}
+
+body.dark .navbar{
+    border-bottom: 1px solid rgba(128, 128, 128, 0.35);
+}
+
+body.dark .home-link img {
+    filter: invert(1) brightness(2);
+}
+
+body.dark div[class*=language-] {
+    background-color: rgb(44, 62, 80);
+}
+
+body.dark .content code {
+    background-color: rgb(44, 62, 80);
+    color: rgb(193, 193, 193);
+}
+
+body.dark .language-text code {
+    color: rgb(177, 177, 177) !important;
+}
+
+body.dark .tabs-component-panels, .tabs-component-tabs li {
+    background: rgba(0, 0, 0, 0);
+    /*border: none;*/
+}
+
+body.dark .tabs-component-panels {
+    border-top: 1px solid rgb(255, 255, 255);
+}
+
+body.dark a.sidebar-link {
+    color: rgb(128, 128, 128);
+}
+
+body.dark code {
+    color: rgb(220, 220, 220) !important;
+}
+
+body.dark a.nav-link.router-link-active {
+    color: rgb(233, 21, 181);
+}
+
+body.dark .search-box input {
+    filter: invert(1);
+}
+
+body.dark ul.nav-dropdown {
+    background: rgb(13, 22, 28) !important;
+}
+
+body.dark tr:nth-child(2n) {
+    background: rgba(0, 0, 0, 0);
+}
+
+body.dark blockquote {
+    background: rgb(44, 62, 80);
+}
+
+body.dark blockquote, body.dark blockquote p {
+    color: rgb(255, 255, 255);
+}
+
+body.dark blockquote a code, body.dark blockquote p code {
+    background: #1c3042 !important;
+}
+
+body.dark a.sidebar-link:hover{
+    color: #d513a5 !important;
+}
+
+#app, .navbar, .sidebar, .links,
+.home-link img,
+div[class*=language-],
+.content code,
+.language-text code,
+.tabs-component-panels, .tabs-component-tabs li,
+.tabs-component-panels,
+code,
+a.nav-link.router-link-active,
+.search-box input,
+ul.nav-dropdown,
+tr:nth-child(2n),
+blockquote,
+blockquote, blockquote p {
+    transition: all .5s ease;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: rgb(218, 216, 216);
+/*  color: #fff;*/
+  text-align: center;
+  border-radius: 6px;
+  padding: 0 7px 0 7px;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip .tooltiptext {
+    top: 25px;
+  right: 0%;
+}
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+</style>
+

--- a/.vuepress/theme/util/dark-mode.js
+++ b/.vuepress/theme/util/dark-mode.js
@@ -1,0 +1,37 @@
+// Original idea by @matiaslopezd, https://github.com/feathersjs/docs/issues/1378
+
+class DarkMode {
+
+  constructor(dark = false) {
+    this._dark = dark;
+    this._key = 'dark-mode-feathers'
+  }
+
+  init() {
+    this._dark = (/true/i).test(window.localStorage.getItem(this._key));
+    if (this._dark) this.toggle(false);
+  }
+
+  toggle(dark = this._dark) {
+    if (dark) {
+      document.body.classList.remove('dark');
+      this._remove();
+    } else {
+      document.body.classList.add('dark');
+      this._save();
+    }
+    this._dark = !dark;
+  }
+
+  _save() {
+    window.localStorage.setItem(this._key, 'true');
+  }
+
+  _remove() {
+    window.localStorage.removeItem(this._key);
+  }
+
+}
+
+export default DarkMode;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,32 @@
       "integrity": "sha512-K+hgi4+tgQwz2ZlqpYTik5AFgDFZ1CcSYrMCqhicR1AwZ9kDsfbU+iD+NYSrsKXVTJJke/kzQIDsBFzcmC4Fkg==",
       "dev": true
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
+      "integrity": "sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.32.tgz",
+      "integrity": "sha512-XjqyeLCsR/c/usUpdWcOdVtWFVjPbDFBTQkn2fQRrWhhUoxriQohO2RWDxLyUM8XpD+Zzg5xwJ8gqTYGDLeGaQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.32"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.1.tgz",
+      "integrity": "sha512-EFMuKtzRMNbvjab/SvJBaOOpaqJfdSap/Nl6hst7CgrJxwfORR1drdTV6q1Ib/JVzq4xObdTDcT6sqTaXMqfdg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.32"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
+      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1700,7 +1726,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2507,8 +2532,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -2795,7 +2819,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2803,8 +2826,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -3454,8 +3476,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -4499,7 +4520,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -6680,7 +6700,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -7739,7 +7758,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
       "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -7748,7 +7766,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -7771,8 +7788,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -7917,8 +7933,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -9254,8 +9269,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -9601,8 +9615,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -11484,6 +11497,108 @@
         "markdown-it-container": "^2.0.0"
       }
     },
+    "vuepress-plugin-font-awesome": {
+      "version": "1.90.6",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-font-awesome/-/vuepress-plugin-font-awesome-1.90.6.tgz",
+      "integrity": "sha512-j/cXJ6fKJhCgmxQEHMTjf8hl8FWVWEZIH7v8pRD5Ram1DPRvY0mdmkt0tdGuoCGzAsy9WmolO0Eq4QXnJIiyAQ==",
+      "requires": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.19",
+        "@fortawesome/free-solid-svg-icons": "^5.9.0",
+        "@fortawesome/vue-fontawesome": "^0.1.6",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "vuepress-plugin-smooth-scroll": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-smooth-scroll/-/vuepress-plugin-smooth-scroll-0.0.3.tgz",
@@ -11790,8 +11905,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
       "version": "3.1.0",
@@ -11906,8 +12020,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,14 @@
   "scripts": {
     "build": "vuepress build",
     "start": "vuepress dev",
+    "fa:build": "node node_modules/vuepress-plugin-font-awesome/index.js",
     "netlify": "npm run build",
     "validate-links": "node scripts/validate-links"
   },
   "directories": {},
-  "dependencies": {},
+  "dependencies": {
+    "vuepress-plugin-font-awesome": "^1.90.6"
+  },
   "devDependencies": {
     "@dovyp/vuepress-plugin-clipboard-copy": "^1.0.0-alpha.7",
     "remark": "^11.0.2",


### PR DESCRIPTION
An implementation of the suggestions of @matiaslopezd.

The dark mode CSS can be changed in `theme/layouts/Layout.vue`. Had to implement Font Awesome to get the Lightbulb (and ThumbsUp), but tree-shaking makes this a minor addition.

Hopefully, Dark-Moders will thrive with this addition!