### PR TITLE
Added API Key Authentication Strategy in Cookbook 

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -103,6 +103,7 @@ module.exports = {
         collapsable: false,
         children: [
           'authentication/anonymous.md',
+          'authentication/apiKey.md',
           'authentication/auth0.md',
           'authentication/facebook.md',
           'authentication/google.md',

--- a/cookbook/authentication/apiKey.md
+++ b/cookbook/authentication/apiKey.md
@@ -139,7 +139,7 @@ export default (): Hook => {
 This hook should be added __before__ the [authenticate hook](../../api/authentication/hook.md) wherever API Key authentication should be allowed:
 
 ```js
-all: [ allowApiKey(), authenticate('jwt', 'anonymous') ],
+all: [ allowApiKey(), authenticate('jwt', 'apiKey') ],
 ```
 
 If a user now accesses the service externally with the correct apiKey, the service call will succeed and have `params.apiKey` set to `true`.

--- a/cookbook/authentication/apiKey.md
+++ b/cookbook/authentication/apiKey.md
@@ -1,0 +1,145 @@
+# API Key Authentication
+
+We will start by providing the required configuration for this strategy. You should change all of these values as per your requirement.
+
+```js
+{
+  "authentication": {
+    ...otherConfig,
+    "authStrategies": [ ...otherStrategies, "apiKey" ],
+    "apiKey": {
+      "allowedKeys": [ "API_KEY_1", "API_KEY_2" ]
+      "header": "x-access-token",
+      "urlParam": "token"
+    }
+  }
+}
+```
+
+Next we will be creating a [custom strategy](../../api/authentication/strategy.md) that returns the `params` that you would like to use to identify an authenticated user/request.
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "JavaScript"
+In `src/authentication.js`:
+
+```js
+const { AuthenticationBaseStrategy, AuthenticationService } = require('@feathersjs/authentication');
+const { NotAuthenticated } = require('@feathersjs/errors');
+
+class ApiKeyStrategy extends AuthenticationBaseStrategy {
+  async authenticate(authentication) {
+    const { token } = authentication;
+  
+    const config = this.authentication.configuration[this.name];
+
+    const match = config.allowedKeys.includes(token);
+    if (!match) throw new NotAuthenticated('Incorrect API Key');
+  
+    return {
+      apiKey: true
+    }
+  }
+}
+
+module.exports = app => {
+  const authentication = new AuthenticationService(app);
+  // ... authentication service setup
+  authentication.register('apiKey', new ApiKeyStrategy());
+}
+```
+:::
+::: tab "TypeScript"
+```ts
+import { AuthenticationBaseStrategy, AuthenticationResult, AuthenticationService } from '@feathersjs/authentication';
+import { NotAuthenticated } from '@feathersjs/errors': 
+
+class ApiKeyStrategy extends AuthenticationBaseStrategy {
+  async authenticate(authentication: AuthenticationResult) {
+    const { token } = authentication;
+  
+    const config = this.authentication.configuration[this.name];
+
+    const match = config.allowedKeys.includes(token);
+    if (!match) throw new NotAuthenticated('Incorrect API Key');
+  
+    return {
+      apiKey: true
+    }
+  }
+}
+
+export default function(app: Application) {
+  const authentication = new AuthenticationService(app);
+  // ... authentication service setup
+  authentication.register('apiKey', new ApiKeyStrategy());
+}
+```
+:::
+::::
+
+
+Next, we create a hook called `allow-apiKey` that sets `params.authentication` if it does not exist and if `params.provider` exists (which means it is an external call) to use that `apiKey` strategy. We will also provide the capability for the apiKey to either be in a header or in a url param:
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "JavaScript"
+```js
+/* eslint-disable require-atomic-updates */
+module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
+  return async context => {
+    const { params } = context;
+
+    const token =
+      params.query[server.auth.apiKey.urlParam] ||
+      params.headers[server.auth.apiKey.header];
+
+    if (token && params.provider && !params.authentication) {
+      context.params = {
+        ...params,
+        authentication: {
+          strategy: 'apiKey',
+          token
+        }
+      };
+    }
+
+    return context;
+  };
+};
+```
+:::
+::: tab "TypeScript"
+```ts
+import { Hook, HookContext } from '@feathersjs/feathers';
+
+export default (): Hook => {
+  return async (context: HookContext) => {
+    const { params } = context;
+
+    const token =
+      params.query[server.auth.apiKey.urlParam] ||
+      params.headers[server.auth.apiKey.header];
+
+    if (token && params.provider && !params.authentication) {
+      context.params = {
+        ...params,
+        authentication: {
+          strategy: 'apiKey',
+          token
+        }
+      };
+    }
+
+    return context;
+  }
+}
+```
+:::
+::::
+
+This hook should be added __before__ the [authenticate hook](../../api/authentication/hook.md) wherever anonymous authentication should be allowed:
+
+```js
+all: [ allowApiKey(), authenticate('jwt', 'anonymous') ],
+```
+
+If a user now accesses the service externally with the correct apiKey, the service call will succeed and have `params.apiKey` set to `true`.

--- a/cookbook/authentication/apiKey.md
+++ b/cookbook/authentication/apiKey.md
@@ -116,8 +116,8 @@ export default (): Hook => {
     const { params } = context;
 
     const token =
-      params.query[server.auth.apiKey.urlParam] ||
-      params.headers[server.auth.apiKey.header];
+      params.query[configuration.apiKey.urlParam] ||
+      params.headers[configuration.apiKey.header];
 
     if (token && params.provider && !params.authentication) {
       context.params = {
@@ -136,7 +136,7 @@ export default (): Hook => {
 :::
 ::::
 
-This hook should be added __before__ the [authenticate hook](../../api/authentication/hook.md) wherever anonymous authentication should be allowed:
+This hook should be added __before__ the [authenticate hook](../../api/authentication/hook.md) wherever API Key authentication should be allowed:
 
 ```js
 all: [ allowApiKey(), authenticate('jwt', 'anonymous') ],


### PR DESCRIPTION
Have created a new example of an API Key Authentication Strategy since it was a little more involved than the already existing Anonymous Strategy and also a common enough use case.