### PR TITLE
Correct syntax of $in example in querying.md

### DIFF
--- a/api/databases/querying.md
+++ b/api/databases/querying.md
@@ -122,7 +122,7 @@ app.service('messages').find({
 ```
 
 ```
-GET /messages?roomId[$in]=2&roomId[$in]=5
+GET /messages?roomId[$in][0]=2&roomId[$in][1]=5
 ```
 
 ## `$lt`, `$lte`

--- a/api/databases/querying.md
+++ b/api/databases/querying.md
@@ -122,7 +122,7 @@ app.service('messages').find({
 ```
 
 ```
-GET /messages?roomId[$in][0]=2&roomId[$in][1]=5
+GET /messages?roomId[$in][]=2&roomId[$in][]=5
 ```
 
 ## `$lt`, `$lte`


### PR DESCRIPTION
$in expects an array. So, this breaks if there is a single item. e.g. GET GET /messages?roomId[$in]=2 will fail.
Please see here:
https://feathersjs.slack.com/archives/C0HJE6A65/p1610228957226400