### PR TITLE
Updating docs to indicate node pm2 also uses `username` environment variable if not escaped

### DIFF
--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -41,7 +41,7 @@ Standard local authentication can be configured with those options in `config/de
 }
 ```
 
-> __Important:__ If you want to set the value of `usernameField` to `username` in your configuration file under Windows, the value has to be escaped as `\\username` (otherwise the `username` environment variable will be used).
+> __Important:__ If you want to set the value of `usernameField` to `username` in your configuration file under Windows or running PM2 in Ubuntu/Linux, the value has to be escaped as `\\username` (otherwise the `username` environment variable will be used).
 
 ## LocalStrategy
 

--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -41,7 +41,7 @@ Standard local authentication can be configured with those options in `config/de
 }
 ```
 
-> __Important:__ If you want to set the value of `usernameField` to `username` in your configuration file under Windows or running PM2 in Ubuntu/Linux, the value has to be escaped as `\\username` (otherwise the `username` environment variable will be used).
+> __Important:__ If you want to set the value of `usernameField` to `username` in your configuration file under Windows or running the node process manager `PM2` in Ubuntu/Linux, the value has to be escaped as `\\username` (otherwise the `username` environment variable will be used).
 
 ## LocalStrategy
 


### PR DESCRIPTION
Updating documentation informing users to escape userField: `\\username` if running Feathers with PM2, as it also just pulls the local environment variable username instead of the usernameField.