### PR TITLE
Change storageKey value to feathers-jwt in example

### DIFF
--- a/api/authentication/client.md
+++ b/api/authentication/client.md
@@ -36,9 +36,7 @@ const app = feathers();
 app.configure(socketio(socket));
 
 // Available options are listed in the "Options" section
-app.configure(auth({
-  storageKey: 'feathers-jwt'
-}))
+app.configure(auth())
 ```
 
 > __Note:__ Verifying or parsing the token on the client usually isn't necessary since the server does that on JWT authentication and returns with the token information but it can still be done manually with the [jwt-decode](https://www.npmjs.com/package/jwt-decode) package.

--- a/api/authentication/client.md
+++ b/api/authentication/client.md
@@ -37,7 +37,7 @@ app.configure(socketio(socket));
 
 // Available options are listed in the "Options" section
 app.configure(auth({
-  storageKey: 'auth'
+  storageKey: 'feathers-jwt'
 }))
 ```
 


### PR DESCRIPTION
I was just trying to run the code with ra-data-feathers but it didn't work. After debugging, I discovered that the @feathersjs/authentication-client setup script that I copy/paste from this doc is using a different field name.

`auth` is used in the docs of @feathersjs/authentication-client, in the library itself default is `feathers-jwt`, and  `token` in the ra-data-feathers. it's a complete mess :(

Since new users often run the code by copying examples from the documentation, in order not to create unnecessary obstacles and problems for other new users, I think it will be useful to add this fix (I also made a request to the [ra-data-feathers](https://github.com/josx/ra-data-feathers/pull/165) to correct the value to the same).