### PR TITLE
fix helmet compatibility and remove innerHTML use in starter code

### DIFF
--- a/guides/basics/starting.md
+++ b/guides/basics/starting.md
@@ -459,7 +459,7 @@ Now we can look at one of the really cool features of Feathers. It works the sam
       const messages = await app.service('messages').find();
 
       // Add existing messages to the list
-      messages.data.forEach(addMessage);
+      messages.forEach(addMessage);
 
       // Add any newly created message to the list in real-time
       app.service('messages').on('created', addMessage);

--- a/guides/basics/starting.md
+++ b/guides/basics/starting.md
@@ -411,12 +411,13 @@ Now we can look at one of the really cool features of Feathers. It works the sam
 <body>
   <main id="main" class="container">
     <h1>Welcome to Feathers</h1>
-    <form class="form" onsubmit="sendMessage(event.preventDefault())">
+    <form class="form" id="message-form">
       <input type="text" id="message-text" placeholder="Enter message here">
       <button type="submit" class="button button-primary">Send message</button>
     </form>
 
     <h2>Here are the current messages:</h2>
+    <pre id="messages"></pre>
   </main>
 
   <script src="//unpkg.com/@feathersjs/client@^4.3.0/dist/feathers.js"></script>
@@ -444,21 +445,27 @@ Now we can look at one of the really cool features of Feathers. It works the sam
 
     // Renders a single message on the page
     function addMessage (message) {
-      document.getElementById('main').innerHTML += `<p>${message.text}</p>`;
+      document.getElementById('messages').textContent += `${message.text}\n`
     }
     
     const main = async () => {
+      const form = document.getElementById('message-form')
+      form.addEventListener('submit', (e) => {
+        e.preventDefault()
+        sendMessage()
+      })
+    
       // Find all existing messages
       const messages = await app.service('messages').find();
 
       // Add existing messages to the list
-      messages.forEach(addMessage);
+      messages.data.forEach(addMessage);
 
       // Add any newly created message to the list in real-time
       app.service('messages').on('created', addMessage);
     };
 
-    main();
+    window.addEventListener('DOMContentLoaded', main);
   </script>
 </body>
 </html>


### PR DESCRIPTION
Starter code has the following issues:
- inline attribute script, which the default feathers(helmet()) call disallows
- innerHTML which will break any event listeners in #493
    - injection hazard

# Screenshot of this exact code actually working...

Note:
- The server is running dove. The client is unchanged 4.3
- Messages are still not sorted, leaving that as exercise for the reader

![Screenshot from 2021-09-22 21-07-11](https://user-images.githubusercontent.com/876076/134445160-b4c58323-7ed0-4722-b5c7-07c6ed74bb0b.png)
