### PR TITLE
Update apiKey.md

### DIFF
--- a/cookbook/authentication/apiKey.md
+++ b/cookbook/authentication/apiKey.md
@@ -136,6 +136,9 @@ export default (): Hook => {
 This hook should be added __before__ the [authenticate hook](../../api/authentication/hook.md) wherever API Key authentication should be allowed:
 
 ```js
+import { authenticate } from '@feathersjs/authentication/lib/hooks';
+import allowApiKey from './hooks/allow-api-key';
+
 all: [ allowApiKey(), authenticate('jwt', 'apiKey') ],
 ```
 


### PR DESCRIPTION
Avoid confusion of which import to use on app.hooks.ts.
Intellisense will auto add import of wrong "authenticate" library.