### PR TITLE
Update google.md

### DIFF
--- a/cookbook/authentication/google.md
+++ b/cookbook/authentication/google.md
@@ -48,7 +48,7 @@ The client id (App ID) and secret can be acquired by creating a [OAuth client ID
 
 **Important**: Fill in the callback url, in a default Feathers setup it will be /oauth/google/callback.
 
-3. Replace <App ID> and <App Secret> with the id and secret of the created OAuth client ID application
+3. Replace `<App ID>` and `<App Secret>` with the id and secret of the created OAuth client ID application
   
 ```js
 {
@@ -56,7 +56,7 @@ The client id (App ID) and secret can be acquired by creating a [OAuth client ID
     "oauth": {
       "google": {
         "key": "<client-id>.apps.googleusercontent.com",
-        "secret": "<client ecret>",
+        "secret": "<client-secret>",
         "scope": ["openid", "email"],
         "nonce": true
       }
@@ -64,7 +64,12 @@ The client id (App ID) and secret can be acquired by creating a [OAuth client ID
   }
 }
 ```
+
 Note: Use the generated credentials of the OAuth client ID.
+
+Note: `<client-id>` will be replaced by a string similar to **481298021138-hv27glb811ocr7pdon5lsg8hh5a6pgjv**.apps.googleusercontent.com.
+
+Note: `<client-secret>` will be replaced by a string similar to **XkWl0witdP4ogeNIgyOi-CeS**.
 
 ## Using the data returned from the Google App through a custom OAuth Strategy
 


### PR DESCRIPTION
Make <App ID> and <App Secret> visible in the rendered Markdown.
Add explicit example so that people can relate to the format shown in the full password. (it's the exact same client id and secret that used to be in the code itself, I put it in there so that people could relate to the format, the credentials have been removed before posting the documentation).