### PR TITLE
fix(oauth): authentication payload expects 'accessToken' not 'access_token'  

### DIFF
--- a/api/authentication/oauth.md
+++ b/api/authentication/oauth.md
@@ -1,4 +1,4 @@
-# OAuth
+access_token# OAuth
 
 [![npm version](https://img.shields.io/npm/v/@feathersjs/authentication-oauth.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication-oauth)
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/crow/packages/authentication-oauth/CHANGELOG.md)
@@ -101,7 +101,7 @@ There are two ways to initiate OAuth authentication:
     - The frontend (e.g. [authentication client](./client.md)) uses the returned access token to authenticate
 
 2) With an existing access token, e.g. obtained through the Facebook mobile SDK
-    - Authenticate normally with `{ strategy: '<name>', access_token: 'oauth access token' }`.
+    - Authenticate normally with `{ strategy: '<name>', accessToken: 'oauth access token' }`.
     - Calls the [OauthStrategy](#oauthstrategy) which
         - Gets the users profile
         - Finds or creates the entity for that profile

--- a/api/authentication/oauth.md
+++ b/api/authentication/oauth.md
@@ -1,4 +1,4 @@
-access_token# OAuth
+# OAuth
 
 [![npm version](https://img.shields.io/npm/v/@feathersjs/authentication-oauth.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication-oauth)
 [![Changelog](https://img.shields.io/badge/changelog-.md-blue.svg?style=flat-square)](https://github.com/feathersjs/feathers/blob/crow/packages/authentication-oauth/CHANGELOG.md)


### PR DESCRIPTION
Despite the access token being passed into the url after successfull oauth flow in snake case ('access_token'), the payload of the authentication service expects the key to be passed in camel case ('accessToken'). The exact place where 'accessToken' is destructured/used can be seen bellow:

```javascript
// from feathers/packages/authentication/src/jwt.ts

async authenticate (authentication: AuthenticationRequest, params: Params) {
    const { accessToken } = authentication; // <----- THIS LINE
    const { entity } = this.configuration;

    if (!accessToken) {
      throw new NotAuthenticated('No access token');
    }

    const payload = await this.authentication.verifyAccessToken(accessToken, params.jwt);
    const result = {
      accessToken,
      authentication: {
        strategy: 'jwt',
        accessToken,
        payload
      }
    };

    if (entity === null) {
      return result;
    }

    const entityId = await this.getEntityId(result, params);
    const value = await this.getEntity(entityId, params);

    return {
      ...result,
      [entity]: value
    };
  }
```
We could otherwise also allow both if this is desired with for example:
```javascript
const accessToken = authentication.accessToken || authentication.access_token
```
It this would be better, let me know and I can do a quick update to the feathers-authentication package (jwt.ts) to allow for this.

Many thanks!