### PR TITLE
Replace Jade with Pug as example template engine

### DIFF
--- a/cookbook/express/view-engine.md
+++ b/cookbook/express/view-engine.md
@@ -8,13 +8,13 @@ You probably already know that when you register a Feathers service, Feathers cr
 
 > **ProTip:** Your own defined REST endpoints won't work with hooks and won't emit socket events. If you find you need that functionality it's probably better for you to turn your endpoints into a minimal Feathers service.
 
-Let's say you want to render a list of messages from most recent to oldest using the Jade template engine.
+Let's say you want to render a list of messages from most recent to oldest using the [Pug](https://pugjs.org/) template engine.
 
 ```js
 // You've set up your main Feathers app already
 
 // Register your view engine
-app.set('view engine', 'jade');
+app.set('view engine', 'pug');
 
 // Register your message service
 app.use('/api/messages', memory());
@@ -30,7 +30,7 @@ app.get('/messages', function(req, res, next){
 });
 ```
 
-Simple right? We've now rendered a list of messages. All your hooks will get triggered just like they would normally so you can use hooks to pre-filter your data and keep your template rendering routes super tight.
+Simple right? We've now rendered a list of messages using the `/views/message-list.pug` view template. All your hooks will get triggered just like they would normally so you can use hooks to pre-filter your data and keep your template rendering routes super tight. See [Using Template Engines with Express](https://expressjs.com/en/guide/using-template-engines.html) for more information.
 
 > **ProTip:** If you call a Feathers service "internally" (ie. not over sockets or REST) you won't have a `context.params.provider` attribute. This allows you to have hooks only execute when services are called externally vs. from your own code.
 


### PR DESCRIPTION
Jade project was renamed to Pug in 2015.  This page seems really old to use Jade as an example template engine.

I've added link to Pug website, mentioned path to pug template file that would be used and link to Express guide on using template engines that also happens to use Pug as example view template engine.