### PR TITLE
Fix errors in the Feathers guide

### DIFF
--- a/guides/basics/testing.md
+++ b/guides/basics/testing.md
@@ -168,7 +168,7 @@ describe('\'users\' service', () => {
   });
 
   it('creates a user, encrypts password and adds gravatar', async () => {
-    const user = await app.service('users').create({
+    const user: any = await app.service('users').create({
       email: 'test@example.com',
       password: 'secret'
     });
@@ -183,7 +183,7 @@ describe('\'users\' service', () => {
     // Setting `provider` indicates an external request
     const params = { provider: 'rest' };
 
-    const user = await app.service('users').create({
+    const user: any = await app.service('users').create({
       email: 'test2@example.com',
       password: 'secret'
     }, params);
@@ -254,7 +254,7 @@ describe('\'messages\' service', () => {
 
   it('creates and processes message, adds user information', async () => {
     // Create a new user we can use for testing
-    const user = await app.service('users').create({
+    const user: any = await app.service('users').create({
       email: 'messagetest@example.com',
       password: 'supersecret'
     });


### PR DESCRIPTION
The TypeScript version of the guide has some missing "any" types in the tests added during the final section of the guide.
This pull request fixes those omissions, matching the current state of [feathers-chat-ts](https://github.com/feathersjs/feathers-chat-ts).