### PR TITLE
fix: remove app.listen(..).on broken function

### DIFF
--- a/guides/basics/starting.md
+++ b/guides/basics/starting.md
@@ -359,7 +359,7 @@ app.on('connection', connection =>
 app.publish(data => app.channel('everybody'));
 
 // Start the server
-app.listen(3030).on('listening', () =>
+app.listen(3030, () =>
   console.log('Feathers server listening on localhost:3030')
 );
 


### PR DESCRIPTION
When I tried to run the code for the app.js in the "An API Server" part of the tutorial, I got this error : 
TypeError: app.listen(...).on is not a function

I am using node v16.13.2 and npm 8.7.0.

I replaced the function causing the error with a working syntax and the app launched correctly.