### PR TITLE
update usage example in dove for koa

### DIFF
--- a/api/koa.md
+++ b/api/koa.md
@@ -23,7 +23,7 @@ const app = koa(feathers());
 app.use(errorHandler());
 app.use(authentication());
 app.use(bodyParser());
-app.use(rest());
+app.configure(rest());
 ```
 
 `@feathersjs/koa` also exposes the following middleware:


### PR DESCRIPTION
Motivation
* I copy-pasted the old way with `app.use(rest())` and it led to a runtime http response error like `app.use is not a function`. I think it's because `rest()` is expected to be passed to `app.configure()` and not `app.use()`.